### PR TITLE
Remove PartialOrd and Ord implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,12 @@ matrix:
       - rustup component add rustfmt-preview
       script:
       - cargo fmt --all -- --check
+      - |
+        for dir in examples/*/
+        do
+            dir=${dir%*/}
+            cd ${dir%*/} && cargo fmt --all -- --check && cd -
+        done
     - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu
       before_script:
       - rustup component add clippy-preview

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ matrix:
     #- env: TARGET=x86_64-sun-solaris NORUN=1
 
     # FIXME: TBD
+    - env: TARGET=arm-linux-androideabi
     - env: TARGET=aarch64-linux-android
 
     # FIXME: iOS

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -122,6 +122,11 @@ case ${TARGET} in
         export RUSTFLAGS=${ORIGINAL_RUSFTFLAGS}
         ;;
     armv7*)
+        if [[ ${TARGET} == *"ios"* ]]; then
+            echo "ERROR: ${TARGET} must run in the iOS simulator"
+            exit 1
+        fi
+
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -130,6 +135,11 @@ case ${TARGET} in
         cargo_test "--release --features=into_bits,coresimd"
         ;;
     arm*)
+        if [[ ${TARGET} == *"ios"* ]]; then
+            echo "ERROR: ${TARGET} must run in the iOS simulator"
+            exit 1
+        fi
+
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -138,6 +148,11 @@ case ${TARGET} in
         cargo_test "--release --features=into_bits,coresimd"
         ;;
     aarch64*)
+        if [[ ${TARGET} == *"ios"* ]]; then
+            echo "ERROR: ${TARGET} must run in the iOS simulator"
+            exit 1
+        fi
+
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -176,6 +191,11 @@ case ${TARGET} in
         export RUSTFLAGS=${ORIGINAL_RUSFTFLAGS}
         ;;
     *)
+        if [[ ${TARGET} == *"ios"* ]]; then
+            echo "ERROR: ${TARGET} must run in the iOS simulator"
+            exit 1
+        fi
+
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -186,7 +206,6 @@ esac
 # Need to copy them to the target directory for the Cargo.lock to be
 # properly written.
 mkdir target || true
-
 
 # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/55
 # All examples fail to build for `armv7-apple-ios`.
@@ -217,5 +236,3 @@ cp -r examples/aobench target/aobench
 cargo_test "--manifest-path=target/aobench/Cargo.toml"
 cargo_test "--release --manifest-path=target/aobench/Cargo.toml --no-default-features"
 cargo_test "--release --manifest-path=target/aobench/Cargo.toml --features=256bit"
-
-

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -210,13 +210,11 @@ cargo_test "--release --manifest-path=target/spectral_norm/Cargo.toml"
 
 cp -r examples/fannkuch_redux target/fannkuch_redux
 cargo_test "--manifest-path=target/fannkuch_redux/Cargo.toml"
-<<<<<<< HEAD
-cargo_test "--release" "--manifest-path=target/fannkuch_redux/Cargo.toml"
+cargo_test "--release --manifest-path=target/fannkuch_redux/Cargo.toml"
 
 cp -r examples/aobench target/aobench
 cargo_test "--manifest-path=target/aobench/Cargo.toml"
-cargo_test "--release" "--manifest-path=target/aobench/Cargo.toml --no-default-features"
-cargo_test "--release" "--manifest-path=target/aobench/Cargo.toml --features=256bit"
-=======
-cargo_test "--release --manifest-path=target/fannkuch_redux/Cargo.toml"
->>>>>>> fix bug in ci script
+cargo_test "--release --manifest-path=target/aobench/Cargo.toml --no-default-features"
+cargo_test "--release --manifest-path=target/aobench/Cargo.toml --features=256bit"
+
+

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -135,6 +135,7 @@ case ${TARGET} in
 
         export RUSTFLAGS="${RUSTFLAGS} -C target-feature=+v7,+neon"
         cargo_test "--release --features=into_bits"
+        cargo_test "--release --features=into_bits,coresimd"
         ;;
     aarch64*)
         cargo_test

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -60,11 +60,6 @@ case ${TARGET} in
         cargo_test "--release --features=into_bits"
         ;;
     i586*)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -78,11 +73,6 @@ case ${TARGET} in
         export RUSTFLAGS=${ORIGINAL_RUSFTFLAGS}
         ;;
     i686*)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -122,11 +112,6 @@ case ${TARGET} in
         export RUSTFLAGS=${ORIGINAL_RUSFTFLAGS}
         ;;
     armv7*)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -135,11 +120,6 @@ case ${TARGET} in
         cargo_test "--release --features=into_bits,coresimd"
         ;;
     arm*)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -148,11 +128,6 @@ case ${TARGET} in
         cargo_test "--release --features=into_bits,coresimd"
         ;;
     aarch64*)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
 
@@ -191,14 +166,8 @@ case ${TARGET} in
         export RUSTFLAGS=${ORIGINAL_RUSFTFLAGS}
         ;;
     *)
-        if [[ ${TARGET} == *"ios"* ]]; then
-            echo "ERROR: ${TARGET} must run in the iOS simulator"
-            exit 1
-        fi
-
         cargo_test
         cargo_test "--release --features=into_bits"
-
         ;;
 esac
 

--- a/examples/aobench/benches/random.rs
+++ b/examples/aobench/benches/random.rs
@@ -6,8 +6,8 @@ extern crate aobench_lib;
 #[macro_use]
 extern crate criterion;
 
+use aobench_lib::geometry::f32xN;
 use aobench_lib::random;
-use aobench_lib::geometry::{f32xN};
 use criterion::*;
 
 fn random_scalar(c: &mut Criterion) {

--- a/examples/aobench/src/geometry/mod.rs
+++ b/examples/aobench/src/geometry/mod.rs
@@ -41,10 +41,21 @@ impl IncrV for f32xN {
     type Element = f32;
     #[inline(always)]
     fn incr(x: f32) -> Self {
-        #[cfg(feature = "256bit")] {
-            Self::new(x, x + 1., x + 2., x + 3., x + 4., x + 5., x + 6., x + 7.)
+        #[cfg(feature = "256bit")]
+        {
+            Self::new(
+                x,
+                x + 1.,
+                x + 2.,
+                x + 3.,
+                x + 4.,
+                x + 5.,
+                x + 6.,
+                x + 7.,
+            )
         }
-        #[cfg(not(feature = "256bit"))] {
+        #[cfg(not(feature = "256bit"))]
+        {
             Self::new(x, x + 1., x + 2., x + 3.)
         }
     }
@@ -54,10 +65,12 @@ impl IncrV for u32xN {
     type Element = u32;
     #[inline(always)]
     fn incr(x: u32) -> Self {
-        #[cfg(feature = "256bit")] {
+        #[cfg(feature = "256bit")]
+        {
             Self::new(x, x + 1, x + 2, x + 3, x + 4, x + 5, x + 6, x + 7)
         }
-        #[cfg(not(feature = "256bit"))] {
+        #[cfg(not(feature = "256bit"))]
+        {
             Self::new(x, x + 1, x + 2, x + 3)
         }
     }

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -130,14 +130,12 @@ mod tests {
         let isectxN = rays.intersect(&plane, IsectxN::new());
 
         #[cfg(feature = "256bit")]
-        let expected = m32xN::new(true, false, true, false, true, false, true, false);
+        let expected =
+            m32xN::new(true, false, true, false, true, false, true, false);
         #[cfg(not(feature = "256bit"))]
         let expected = m32xN::new(true, false, true, false);
 
-        assert_eq!(
-            isectxN.hit,
-            expected
-        );
+        assert_eq!(isectxN.hit, expected);
 
         assert_eq!(isect_hit.t, isectxN.t.extract(0));
         assert_eq!(isect_hit.t, isectxN.t.extract(2));

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -53,7 +53,8 @@ impl Intersect<Sphere> for RayxN {
                 isect.t = m.sel(t, isect.t);
                 isect.hit = m | isect.hit;
                 isect.p = m.sel(ray.origin + t * ray.dir, isect.p);
-                isect.n = m.sel((isect.p - sphere.center).normalized(), isect.n);
+                isect.n =
+                    m.sel((isect.p - sphere.center).normalized(), isect.n);
             }
         }
 
@@ -129,14 +130,12 @@ mod tests {
         let isectxN = rays.intersect(&sphere, IsectxN::new());
 
         #[cfg(feature = "256bit")]
-        let expected = m32xN::new(true, false, true, false, true, false, true, false);
+        let expected =
+            m32xN::new(true, false, true, false, true, false, true, false);
         #[cfg(not(feature = "256bit"))]
         let expected = m32xN::new(true, false, true, false);
 
-        assert_eq!(
-            isectxN.hit,
-            expected
-        );
+        assert_eq!(isectxN.hit, expected);
 
         assert_eq!(isect_hit.t, isectxN.t.extract(0));
         assert_eq!(isect_hit.t, isectxN.t.extract(2));

--- a/examples/aobench/src/lib.rs
+++ b/examples/aobench/src/lib.rs
@@ -7,9 +7,9 @@
 #[macro_use]
 extern crate cfg_if;
 extern crate failure;
+extern crate packed_simd;
 extern crate png;
 extern crate rayon;
-extern crate packed_simd;
 
 pub mod ambient_occlusion;
 pub mod geometry;

--- a/examples/aobench/src/scene/mod.rs
+++ b/examples/aobench/src/scene/mod.rs
@@ -8,7 +8,8 @@ pub trait Scene: Send + Sync {
     fn plane(&self) -> &Plane;
     fn spheres(&self) -> &[Sphere];
     fn rand_f32xN(&mut self) -> (f32xN, f32xN) {
-        #[cfg(feature = "256bit")] {
+        #[cfg(feature = "256bit")]
+        {
             let r = [
                 self.rand(),
                 self.rand(),
@@ -32,7 +33,8 @@ pub trait Scene: Send + Sync {
                 f32xN::new(r[1], r[3], r[5], r[7], r[9], r[11], r[13], r[15]),
             )
         }
-        #[cfg(not(feature = "256bit"))] {
+        #[cfg(not(feature = "256bit"))]
+        {
             let r = [
                 self.rand(),
                 self.rand(),

--- a/examples/dot_product/src/simd.rs
+++ b/examples/dot_product/src/simd.rs
@@ -9,7 +9,8 @@ pub fn dot_prod(a: &[f32], b: &[f32]) -> f32 {
     let mut sum = f32x4::splat(0.);
 
     for i in (0..a.len()).step_by(4) {
-        sum += f32x4::from_slice_unaligned(&a[i..]) * f32x4::from_slice_unaligned(&b[i..]);
+        sum += f32x4::from_slice_unaligned(&a[i..])
+            * f32x4::from_slice_unaligned(&b[i..]);
     }
 
     sum.sum()

--- a/examples/matrix_inverse/src/simd.rs
+++ b/examples/matrix_inverse/src/simd.rs
@@ -1,5 +1,5 @@
 //! 4x4 matrix inverse using SIMD
-use ::*;
+use *;
 
 use packed_simd::f32x4;
 
@@ -20,7 +20,6 @@ pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
     let row3: f32x4 = shuffle!(m_2, m_3, [2, 3, 6, 7]);
     let row2 = shuffle!(tmp1, row3, [0, 2, 4, 6]);
     let row3 = shuffle!(row3, tmp1, [1, 3, 5, 7]);
-
 
     let tmp1: f32x4 = row2 * row3;
     let tmp1 = shuffle!(tmp1, [1, 0, 3, 2]);

--- a/examples/nbody/src/lib.rs
+++ b/examples/nbody/src/lib.rs
@@ -17,13 +17,5 @@ pub fn run(n: usize, alg: usize) -> (f64, f64) {
 }
 
 #[cfg(test)]
-#[cfg(not(debug_assertions))]
-const RESULTS: &[(usize, &str, &str)] = &[
-    (1_000_usize, "-0.169075164", "-0.169087605"),
-    (50_000_000_usize, "-0.169075164", "-0.169059907"),
-];
-
-#[cfg(test)]
-#[cfg(debug_assertions)]
 const RESULTS: &[(usize, &str, &str)] =
     &[(1_000_usize, "-0.169075164", "-0.169087605")];

--- a/examples/spectral_norm/src/lib.rs
+++ b/examples/spectral_norm/src/lib.rs
@@ -10,8 +10,6 @@ fn A(i: usize, j: usize) -> f64 {
     ((i + j) * (i + j + 1) / 2 + i + 1) as f64
 }
 
-
-
 pub fn spectral_norm(n: usize, alg: usize) -> f64 {
     match alg {
         0 => simd::spectral_norm(n),

--- a/examples/spectral_norm/src/main.rs
+++ b/examples/spectral_norm/src/main.rs
@@ -7,7 +7,11 @@ fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
 }
 
 fn main() {
-    let n: usize = std::env::args().nth(1).expect("need one arg").parse().unwrap();
+    let n: usize = std::env::args()
+        .nth(1)
+        .expect("need one arg")
+        .parse()
+        .unwrap();
 
     let alg = if let Some(v) = std::env::args().nth(2) {
         v.parse().unwrap()

--- a/examples/spectral_norm/src/scalar.rs
+++ b/examples/spectral_norm/src/scalar.rs
@@ -1,7 +1,10 @@
 //! Scalar spectral norm implementation
 
+use std::{
+    iter::*,
+    ops::{Add, Div},
+};
 use *;
-use std::{ops::{Add, Div}, iter::*};
 
 struct f64x2(f64, f64);
 impl Add for f64x2 {
@@ -43,7 +46,9 @@ fn mult_Atv(v: &[f64], out: &mut [f64]) {
 }
 
 fn mult<F>(v: &[f64], out: &mut [f64], start: usize, a: F)
-           where F: Fn(usize, usize) -> f64 {
+where
+    F: Fn(usize, usize) -> f64,
+{
     for (i, slot) in out.iter_mut().enumerate().map(|(i, s)| (i + start, s)) {
         let mut sum = f64x2(0.0, 0.0);
         for (j, chunk) in v.chunks(2).enumerate().map(|(j, s)| (2 * j, s)) {
@@ -57,7 +62,10 @@ fn mult<F>(v: &[f64], out: &mut [f64], start: usize, a: F)
 }
 
 fn dot(x: &[f64], y: &[f64]) -> f64 {
-    x.iter().zip(y).map(|(&x, &y)| x * y).fold(0.0, |a, b| a + b)
+    x.iter()
+        .zip(y)
+        .map(|(&x, &y)| x * y)
+        .fold(0.0, |a, b| a + b)
 }
 
 #[cfg(test)]

--- a/examples/spectral_norm/src/simd.rs
+++ b/examples/spectral_norm/src/simd.rs
@@ -60,7 +60,10 @@ pub fn spectral_norm(n: usize) -> f64 {
 
 fn dot(x: &[f64], y: &[f64]) -> f64 {
     // This is auto-vectorized:
-    x.iter().zip(y).map(|(&x, &y)| x * y).fold(0.0, |a, b| a + b)
+    x.iter()
+        .zip(y)
+        .map(|(&x, &y)| x * y)
+        .fold(0.0, |a, b| a + b)
 }
 
 #[cfg(test)]

--- a/src/api/cmp/eq.rs
+++ b/src/api/cmp/eq.rs
@@ -7,6 +7,7 @@ macro_rules! impl_cmp_eq {
         ($true:expr, $false:expr)
     ) => {
         impl ::cmp::Eq for $id {}
+        impl ::cmp::Eq for PartiallyOrdered<$id> {}
 
         #[cfg(test)]
         interpolate_idents! {

--- a/src/api/cmp/ord.rs
+++ b/src/api/cmp/ord.rs
@@ -6,7 +6,15 @@ macro_rules! impl_cmp_ord {
         $id:ident |
         ($true:expr, $false:expr)
     ) => {
-        impl ::cmp::Ord for $id {
+        impl $id {
+            /// Returns a wrapper that implements `Ord`.
+            #[inline]
+            pub fn ord(&self) -> PartiallyOrdered<$id> {
+                PartiallyOrdered(*self)
+            }
+        }
+
+        impl ::cmp::Ord for PartiallyOrdered<$id> {
             #[inline]
             fn cmp(&self, other: &Self) -> ::cmp::Ordering {
                 match self.partial_cmp(other) {
@@ -24,7 +32,8 @@ macro_rules! impl_cmp_ord {
                 fn eq() {
                     fn foo<E: ::cmp::Ord>(_: E) {}
                     let a = $id::splat($false);
-                    foo(a);
+                    foo(a.partial_ord());
+                    foo(a.ord());
                 }
             }
         }

--- a/src/api/cmp/partial_eq.rs
+++ b/src/api/cmp/partial_eq.rs
@@ -19,6 +19,19 @@ macro_rules! impl_cmp_partial_eq {
             }
         }
 
+        // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2892
+        #[cfg_attr(feature = "cargo-clippy", allow(partialeq_ne_impl))]
+        impl ::cmp::PartialEq<PartiallyOrdered<$id>> for PartiallyOrdered<$id> {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.0 == other.0
+            }
+            #[inline]
+            fn ne(&self, other: &Self) -> bool {
+                self.0 != other.0
+            }
+        }
+
         #[cfg(test)]
         interpolate_idents! {
             mod [$id _cmp_PartialEq] {

--- a/src/api/cmp/partial_eq.rs
+++ b/src/api/cmp/partial_eq.rs
@@ -21,7 +21,9 @@ macro_rules! impl_cmp_partial_eq {
 
         // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2892
         #[cfg_attr(feature = "cargo-clippy", allow(partialeq_ne_impl))]
-        impl ::cmp::PartialEq<PartiallyOrdered<$id>> for PartiallyOrdered<$id> {
+        impl ::cmp::PartialEq<PartiallyOrdered<$id>>
+            for PartiallyOrdered<$id>
+        {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 self.0 == other.0

--- a/src/api/cmp/partial_ord.rs
+++ b/src/api/cmp/partial_ord.rs
@@ -4,7 +4,15 @@
 
 macro_rules! impl_cmp_partial_ord {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident) => {
-        impl ::cmp::PartialOrd<$id> for $id {
+        impl $id {
+            /// Returns a wrapper that implements `PartialOrd`.
+            #[inline]
+            pub fn partial_ord(&self) -> PartiallyOrdered<$id> {
+                PartiallyOrdered(*self)
+            }
+        }
+
+        impl ::cmp::PartialOrd<PartiallyOrdered<$id>> for PartiallyOrdered<$id> {
             #[inline]
             fn partial_cmp(&self, other: &Self) -> Option<::cmp::Ordering> {
                 if PartialEq::eq(self, other) {
@@ -19,8 +27,8 @@ macro_rules! impl_cmp_partial_ord {
             }
             #[inline]
             fn lt(&self, other: &Self) -> bool {
-                let m_lt = Self::lt(*self, *other);
-                let m_eq = Self::eq(*self, *other);
+                let m_lt = self.0.lt(other.0);
+                let m_eq = self.0.eq(other.0);
                 for i in 0..$id::lanes() {
                     if m_eq.extract(i) {
                         continue;
@@ -39,8 +47,8 @@ macro_rules! impl_cmp_partial_ord {
             }
             #[inline]
             fn gt(&self, other: &Self) -> bool {
-                let m_gt = Self::gt(*self, *other);
-                let m_eq = Self::eq(*self, *other);
+                let m_gt = self.0.gt(other.0);
+                let m_eq = self.0.eq(other.0);
                 for i in 0..$id::lanes() {
                     if m_eq.extract(i) {
                         continue;
@@ -66,10 +74,10 @@ macro_rules! test_cmp_partial_ord_int {
                     let a = $id::splat(0);
                     let b = $id::splat(1);
 
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     // variable values: a = [0, 1, 2, 3]; b = [3, 2, 1, 0]
                     let mut a = $id::splat(0);
@@ -78,36 +86,36 @@ macro_rules! test_cmp_partial_ord_int {
                         a = a.replace(i, i as $elem_ty);
                         b = b.replace(i, ($id::lanes() - i) as $elem_ty);
                     }
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     // variable values: a = [0, 1, 2, 3]; b = [0, 1, 2, 4]
                     let mut b = a;
                     b = b.replace($id::lanes()-1, a.extract($id::lanes() - 1) + 1 as $elem_ty);
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     if $id::lanes() > 2 {
                         // variable values a = [0, 1, 0, 0]; b = [0, 1, 2, 3]
                         let b = a;
                         let mut a = $id::splat(0);
                         a = a.replace(1, 1 as $elem_ty);
-                        test_cmp(a, b, Some(::cmp::Ordering::Less));
-                        test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                        test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                        test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                        test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                        test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                        test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                        test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                         // variable values: a = [0, 1, 2, 3]; b = [0, 1, 3, 2]
                         let mut b = a;
                         b = b.replace(2, a.extract($id::lanes() - 1) + 1 as $elem_ty);
-                        test_cmp(a, b, Some(::cmp::Ordering::Less));
-                        test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                        test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                        test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                        test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                        test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                        test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                        test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
                     }
                 }
             }
@@ -128,28 +136,28 @@ macro_rules! test_cmp_partial_ord_mask {
                     let a = $id::splat(false);
                     let b = $id::splat(true);
 
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     // variable values: a = [false, false, false, false]; b = [false, false, false, true]
                     let a = $id::splat(false);
                     let mut b = $id::splat(false);
                     b = b.replace($id::lanes() - 1, true);
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     // variable values: a = [true, true, true, false]; b = [true, true, true, true]
                     let mut a = $id::splat(true);
                     let b = $id::splat(true);
                     a = a.replace($id::lanes() - 1, false);
-                    test_cmp(a, b, Some(::cmp::Ordering::Less));
-                    test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                    test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                    test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                    test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                    test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                    test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                    test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
 
                     if $id::lanes() > 2 {
                         // variable values a = [false, true, false, false]; b = [false, true, true, true]
@@ -157,10 +165,10 @@ macro_rules! test_cmp_partial_ord_mask {
                         let mut b = $id::splat(true);
                         a = a.replace(1, true);
                         b = b.replace(0, false);
-                        test_cmp(a, b, Some(::cmp::Ordering::Less));
-                        test_cmp(b, a, Some(::cmp::Ordering::Greater));
-                        test_cmp(a, a, Some(::cmp::Ordering::Equal));
-                        test_cmp(b, b, Some(::cmp::Ordering::Equal));
+                        test_cmp(a.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Less));
+                        test_cmp(b.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Greater));
+                        test_cmp(a.partial_ord(), a.partial_ord(), Some(::cmp::Ordering::Equal));
+                        test_cmp(b.partial_ord(), b.partial_ord(), Some(::cmp::Ordering::Equal));
                     }
                 }
             }

--- a/src/api/cmp/partial_ord.rs
+++ b/src/api/cmp/partial_ord.rs
@@ -12,7 +12,9 @@ macro_rules! impl_cmp_partial_ord {
             }
         }
 
-        impl ::cmp::PartialOrd<PartiallyOrdered<$id>> for PartiallyOrdered<$id> {
+        impl ::cmp::PartialOrd<PartiallyOrdered<$id>>
+            for PartiallyOrdered<$id>
+        {
             #[inline]
             fn partial_cmp(&self, other: &Self) -> Option<::cmp::Ordering> {
                 if PartialEq::eq(self, other) {

--- a/src/api/into_bits/arch_specific.rs
+++ b/src/api/into_bits/arch_specific.rs
@@ -59,12 +59,20 @@ macro_rules! impl_arch {
 // FIXME: arm/aarch float16x4_t missing
 impl_arch!(
     [x86["x86"]: __m64], [x86_64["x86_64"]: __m64],
-    [arm["arm"]: int8x8_t, uint8x8_t, poly8x8_t, int16x4_t, uint16x4_t,
-     poly16x4_t, int32x2_t, uint32x2_t, float32x2_t, int64x1_t,
-     uint64x1_t],
     [aarch64["aarch64"]: int8x8_t, uint8x8_t, poly8x8_t, int16x4_t, uint16x4_t,
      poly16x4_t, int32x2_t, uint32x2_t, float32x2_t, int64x1_t, uint64x1_t,
      float64x1_t] |
+    from: i8x8, u8x8, m8x8, i16x4, u16x4, m16x4, i32x2, u32x2, f32x2, m32x2 |
+    into: i8x8, u8x8, i16x4, u16x4, i32x2, u32x2, f32x2
+);
+
+// FIXME: arm vector types require v7+neon and a re-compiled std library
+#[cfg(all(target_arch = "arm", target_feature = "v7", target_feature = "neon",
+          feature = "coresimd"))]
+impl_arch!(
+    [arm["arm"]: int8x8_t, uint8x8_t, poly8x8_t, int16x4_t, uint16x4_t,
+     poly16x4_t, int32x2_t, uint32x2_t, float32x2_t, int64x1_t,
+     uint64x1_t] |
     from: i8x8, u8x8, m8x8, i16x4, u16x4, m16x4, i32x2, u32x2, f32x2, m32x2 |
     into: i8x8, u8x8, i16x4, u16x4, i32x2, u32x2, f32x2
 );
@@ -83,8 +91,6 @@ impl_arch!(
 impl_arch!(
     [x86["x86"]: __m128, __m128i, __m128d],
     [x86_64["x86_64"]:  __m128, __m128i, __m128d],
-    [arm["arm"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t, uint16x8_t,
-     poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t, uint64x2_t],
     [aarch64["aarch64"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t,
      uint16x8_t, poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t,
      uint64x2_t, float64x2_t],
@@ -95,6 +101,18 @@ impl_arch!(
      vector_signed_short, vector_unsigned_short, vector_signed_int,
      vector_unsigned_int,  vector_float, vector_signed_long,
      vector_unsigned_long, vector_double] |
+    from: i8x16, u8x16, m8x16, i16x8, u16x8, m16x8, i32x4, u32x4, f32x4, m32x4,
+    i64x2, u64x2, f64x2, m64x2, i128x1, u128x1, m128x1 |
+    into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4, i64x2, u64x2, f64x2,
+    i128x1, u128x1
+);
+
+// FIXME: arm vector types require v7+neon and a re-compiled std library
+#[cfg(all(target_arch = "arm", target_feature = "v7", target_feature = "neon",
+          feature = "coresimd"))]
+impl_arch!(
+    [arm["arm"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t, uint16x8_t,
+     poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t, uint64x2_t] |
     from: i8x16, u8x16, m8x16, i16x8, u16x8, m16x8, i32x4, u32x4, f32x4, m32x4,
     i64x2, u64x2, f64x2, m64x2, i128x1, u128x1, m128x1 |
     into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4, i64x2, u64x2, f64x2,

--- a/src/api/into_bits/arch_specific.rs
+++ b/src/api/into_bits/arch_specific.rs
@@ -88,16 +88,29 @@ impl_arch!(
 // FIXME: ppc64 vector_bool_long_long missing
 // FIXME: ppc64 vector_signed___int128 missing
 // FIXME: ppc64 vector_unsigned___int128 missing
+#[cfg(any(
+    // FIXME: arm vector types require v7+neon and a re-compiled std library
+    not(target_arch = "arm"),
+    all(target_feature = "v7", target_feature = "neon",
+        feature = "coresimd")
+))]
+#[cfg(any(
+    // FIXME: powerpc vector types require altivec and a re-compiled std library
+    not(target_arch = "powerpc"),
+    all(target_feature = "altivec", feature = "coresimd"),
+))]
 impl_arch!(
     [x86["x86"]: __m128, __m128i, __m128d],
     [x86_64["x86_64"]:  __m128, __m128i, __m128d],
+    [arm["arm"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t, uint16x8_t,
+     poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t, uint64x2_t],
     [aarch64["aarch64"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t,
      uint16x8_t, poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t,
      uint64x2_t, float64x2_t],
     [powerpc["powerpc"]: vector_signed_char, vector_unsigned_char,
      vector_signed_short, vector_unsigned_short, vector_signed_int,
      vector_unsigned_int, vector_float],
-    [powerpc["powerpc64"]: vector_signed_char, vector_unsigned_char,
+    [powerpc64["powerpc64"]: vector_signed_char, vector_unsigned_char,
      vector_signed_short, vector_unsigned_short, vector_signed_int,
      vector_unsigned_int,  vector_float, vector_signed_long,
      vector_unsigned_long, vector_double] |
@@ -107,21 +120,14 @@ impl_arch!(
     i128x1, u128x1
 );
 
-// FIXME: arm vector types require v7+neon and a re-compiled std library
-#[cfg(all(target_arch = "arm", target_feature = "v7", target_feature = "neon",
-          feature = "coresimd"))]
-impl_arch!(
-    [arm["arm"]: int8x16_t, uint8x16_t, poly8x16_t, int16x8_t, uint16x8_t,
-     poly16x8_t, int32x4_t, uint32x4_t, float32x4_t, int64x2_t, uint64x2_t] |
-    from: i8x16, u8x16, m8x16, i16x8, u16x8, m16x8, i32x4, u32x4, f32x4, m32x4,
-    i64x2, u64x2, f64x2, m64x2, i128x1, u128x1, m128x1 |
-    into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4, i64x2, u64x2, f64x2,
-    i128x1, u128x1
-);
-
+#[cfg(any(
+    // FIXME: powerpc vector types require altivec and a re-compiled std library
+    not(target_arch = "powerpc"),
+    all(target_feature = "altivec", feature = "coresimd"),
+))]
 impl_arch!(
     [powerpc["powerpc"]: vector_bool_char],
-    [powerpc["powerpc64"]: vector_bool_char] |
+    [powerpc64["powerpc64"]: vector_bool_char] |
     from: m8x16, m16x8, m32x4, m64x2, m128x1 |
     into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4,
     i64x2, u64x2, f64x2, i128x1, u128x1,
@@ -129,9 +135,14 @@ impl_arch!(
     m8x16
 );
 
+#[cfg(any(
+    // FIXME: powerpc vector types require altivec and a re-compiled std library
+    not(target_arch = "powerpc"),
+    all(target_feature = "altivec", feature = "coresimd"),
+))]
 impl_arch!(
     [powerpc["powerpc"]: vector_bool_short],
-    [powerpc["powerpc64"]: vector_bool_short] |
+    [powerpc64["powerpc64"]: vector_bool_short] |
     from: m16x8, m32x4, m64x2, m128x1 |
     into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4,
     i64x2, u64x2, f64x2, i128x1, u128x1,
@@ -139,9 +150,14 @@ impl_arch!(
     m8x16, m16x8
 );
 
+#[cfg(any(
+    // FIXME: powerpc vector types require altivec and a re-compiled std library
+    not(target_arch = "powerpc"),
+    all(target_feature = "altivec", feature = "coresimd"),
+))]
 impl_arch!(
     [powerpc["powerpc"]: vector_bool_int],
-    [powerpc["powerpc64"]: vector_bool_int] |
+    [powerpc64["powerpc64"]: vector_bool_int] |
     from: m32x4, m64x2, m128x1 |
     into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4,
     i64x2, u64x2, f64x2, i128x1, u128x1,
@@ -150,7 +166,7 @@ impl_arch!(
 );
 
 impl_arch!(
-    [powerpc["powerpc64"]: vector_bool_long] |
+    [powerpc64["powerpc64"]: vector_bool_long] |
     from: m64x2, m128x1 |
     into: i8x16, u8x16, i16x8, u16x8, i32x4, u32x4, f32x4,
     i64x2, u64x2, f64x2, i128x1, u128x1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,11 @@ pub struct Simd<A: sealed::SimdArray>(
 
 /// Wrapper over `T` implementing `PartialOrd` and/or `Ord`.
 #[repr(transparent)]
-#[derive(Copy,Clone,Debug)]
-#[cfg_attr(feature = "cargo-clippy", allow(missing_inline_in_public_items))]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(
+    feature = "cargo-clippy",
+    allow(missing_inline_in_public_items)
+)]
 pub struct PartiallyOrdered<T>(T);
 
 mod masks;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ mod sealed;
 #[cfg(test)]
 mod test_utils;
 
-/// Packed vector type
+/// Packed SIMD vector type.
 ///
 /// # Examples
 ///
@@ -277,6 +277,12 @@ pub struct Simd<A: sealed::SimdArray>(
     // to call the shuffle intrinsics.
     #[doc(hidden)] pub <A as sealed::SimdArray>::Tuple,
 );
+
+/// Wrapper over `T` implementing `PartialOrd` and/or `Ord`.
+#[repr(transparent)]
+#[derive(Copy,Clone,Debug)]
+#[cfg_attr(feature = "cargo-clippy", allow(missing_inline_in_public_items))]
+pub struct PartiallyOrdered<T>(T);
 
 mod masks;
 pub use self::masks::*;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,9 +1,11 @@
 //! Test utilities
 
-use crate::{cmp::PartialOrd, fmt::Debug};
+use crate::{cmp::PartialOrd, fmt::Debug, PartiallyOrdered};
 
 /// Tests PartialOrd for `a` and `b` where `a < b` is true.
-pub fn test_lt<T: PartialOrd + Debug>(a: T, b: T) {
+pub fn test_lt<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
+    where PartiallyOrdered<T>: Debug + PartialOrd
+{
     assert!(a < b, "{:?}, {:?}", a, b);
     assert!(b > a, "{:?}, {:?}", a, b);
 
@@ -24,7 +26,9 @@ pub fn test_lt<T: PartialOrd + Debug>(a: T, b: T) {
 }
 
 /// Tests PartialOrd for `a` and `b` where `a <= b` is true.
-pub fn test_le<T: PartialOrd + Debug>(a: T, b: T) {
+pub fn test_le<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
+    where PartiallyOrdered<T>: Debug + PartialOrd
+{
     assert!(a <= b, "{:?}, {:?}", a, b);
     assert!(b >= a, "{:?}, {:?}", a, b);
 
@@ -43,9 +47,10 @@ pub fn test_le<T: PartialOrd + Debug>(a: T, b: T) {
 }
 
 /// Test PartialOrd::partial_cmp for `a` and `b` returning `Ordering`
-pub fn test_cmp<T>(a: T, b: T, o: Option<::cmp::Ordering>)
-where
-    T: PartialOrd + Debug + crate::sealed::Simd + Copy + Clone,
+pub fn test_cmp<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>, o: Option<::cmp::Ordering>)
+    where
+    PartiallyOrdered<T>: PartialOrd + Debug,
+    T: Debug + crate::sealed::Simd + Copy + Clone,
     <T as crate::sealed::Simd>::Element: Default + Copy + Clone + PartialOrd,
 {
     assert!(
@@ -55,8 +60,8 @@ where
     let mut arr_a: [T::Element; 64] = [Default::default(); 64];
     let mut arr_b: [T::Element; 64] = [Default::default(); 64];
 
-    unsafe { crate::ptr::write_unaligned(arr_a.as_mut_ptr() as *mut T, a) }
-    unsafe { crate::ptr::write_unaligned(arr_b.as_mut_ptr() as *mut T, b) }
+    unsafe { crate::ptr::write_unaligned(arr_a.as_mut_ptr() as *mut PartiallyOrdered<T>, a) }
+    unsafe { crate::ptr::write_unaligned(arr_b.as_mut_ptr() as *mut PartiallyOrdered<T>, b) }
     let expected = arr_a[0..T::LANES].partial_cmp(&arr_b[0..T::LANES]);
     let result = a.partial_cmp(&b);
     assert_eq!(expected, result, "{:?}, {:?}", a, b);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,7 +4,8 @@ use crate::{cmp::PartialOrd, fmt::Debug, PartiallyOrdered};
 
 /// Tests PartialOrd for `a` and `b` where `a < b` is true.
 pub fn test_lt<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
-    where PartiallyOrdered<T>: Debug + PartialOrd
+where
+    PartiallyOrdered<T>: Debug + PartialOrd,
 {
     assert!(a < b, "{:?}, {:?}", a, b);
     assert!(b > a, "{:?}, {:?}", a, b);
@@ -27,7 +28,8 @@ pub fn test_lt<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
 
 /// Tests PartialOrd for `a` and `b` where `a <= b` is true.
 pub fn test_le<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
-    where PartiallyOrdered<T>: Debug + PartialOrd
+where
+    PartiallyOrdered<T>: Debug + PartialOrd,
 {
     assert!(a <= b, "{:?}, {:?}", a, b);
     assert!(b >= a, "{:?}, {:?}", a, b);
@@ -47,8 +49,11 @@ pub fn test_le<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>)
 }
 
 /// Test PartialOrd::partial_cmp for `a` and `b` returning `Ordering`
-pub fn test_cmp<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>, o: Option<::cmp::Ordering>)
-    where
+pub fn test_cmp<T>(
+    a: PartiallyOrdered<T>,
+    b: PartiallyOrdered<T>,
+    o: Option<::cmp::Ordering>,
+) where
     PartiallyOrdered<T>: PartialOrd + Debug,
     T: Debug + crate::sealed::Simd + Copy + Clone,
     <T as crate::sealed::Simd>::Element: Default + Copy + Clone + PartialOrd,
@@ -60,8 +65,18 @@ pub fn test_cmp<T>(a: PartiallyOrdered<T>, b: PartiallyOrdered<T>, o: Option<::c
     let mut arr_a: [T::Element; 64] = [Default::default(); 64];
     let mut arr_b: [T::Element; 64] = [Default::default(); 64];
 
-    unsafe { crate::ptr::write_unaligned(arr_a.as_mut_ptr() as *mut PartiallyOrdered<T>, a) }
-    unsafe { crate::ptr::write_unaligned(arr_b.as_mut_ptr() as *mut PartiallyOrdered<T>, b) }
+    unsafe {
+        crate::ptr::write_unaligned(
+            arr_a.as_mut_ptr() as *mut PartiallyOrdered<T>,
+            a,
+        )
+    }
+    unsafe {
+        crate::ptr::write_unaligned(
+            arr_b.as_mut_ptr() as *mut PartiallyOrdered<T>,
+            b,
+        )
+    }
     let expected = arr_a[0..T::LANES].partial_cmp(&arr_b[0..T::LANES]);
     let result = a.partial_cmp(&b);
     assert_eq!(expected, result, "{:?}, {:?}", a, b);


### PR DESCRIPTION
The vectors for which a partial ordering exists
have a `vec::partial_ord(&self)` method that
returns a wrapper that implements at least `PartialOrd`.
These wrapper implements `Ord` when possible.

The vectors for which a total ordering exists have
a `vec::ord(&self)` method that returns a wrapper
that implements `Ord`.

Closes #48.