### PR TITLE
SSE4.1 mask codegen

### DIFF
--- a/src/codegen/reductions/mask.rs
+++ b/src/codegen/reductions/mask.rs
@@ -92,6 +92,38 @@ cfg_if! {
             };
         }
 
+        /// x86/x86_64 128-bit SSE4.1 implementation
+        #[cfg(target_feature = "sse4.1")]
+        macro_rules! x86_128_sse41_impl {
+            ($id:ident) => {
+                impl All for $id {
+                    #[inline]
+                    #[target_feature(enable = "sse4.1")]
+                    unsafe fn all(self) -> bool {
+                        #[cfg(target_arch = "x86")]
+                        use ::arch::x86::_mm_test_all_ones;
+                        #[cfg(target_arch = "x86_64")]
+                        use ::arch::x86_64::_mm_test_all_ones;
+                        // _mm_test_all_ones(a, a) returns a 1 if all bits of
+                        // `a` are set, 0 if not.
+                        _mm_test_all_ones(::mem::transmute(self)) == 1
+                    }
+                }
+                impl Any for $id {
+                    #[inline]
+                    #[target_feature(enable = "sse4.1")]
+                    unsafe fn any(self) -> bool {
+                        #[cfg(target_arch = "x86")]
+                        use ::arch::x86::_mm_test_all_zeros;
+                        #[cfg(target_arch = "x86_64")]
+                        use ::arch::x86_64::_mm_test_all_zeros;
+
+                        _mm_test_all_zeros(::mem::transmute(self), ::mem::transmute(self))
+                            == 0
+                    }
+                }
+            };
+        }
         /// x86/x86_64 128-bit SSE2 implementation
         #[cfg(target_feature = "sse2")]
         macro_rules! x86_128_sse2_impl {
@@ -195,7 +227,9 @@ cfg_if! {
         macro_rules! x86_128_impl {
             ($id:ident) => {
                 cfg_if! {
-                    if #[cfg(target_feature = "sse2")] {
+                    if #[cfg(target_feature = "sse4.1")] {
+                        x86_128_sse41_impl!($id);
+                    } else if #[cfg(target_feature = "sse2")] {
                         x86_128_sse2_impl!($id);
                     }  else {
                         fallback_impl!($id);


### PR DESCRIPTION
This should save a compare instruction over the SSE2 impl, a welcome improvement as these are likely to be used in hot code.

Note: there are also `_testc_si/_testz_si` instructions like the 256-bit AVX codegen. I don't know if there's any meaningful difference.