### PR TITLE
improve codegen for shuffle_bytes

### DIFF
--- a/src/api/shuffle_bytes.rs
+++ b/src/api/shuffle_bytes.rs
@@ -32,10 +32,10 @@ macro_rules! impl_shuffle_bytes {
                             v
                         };
 
-                        assert_eq!(increasing.shuffle_bytes(increasing), increasing);
-                        assert_eq!(decreasing.shuffle_bytes(increasing), decreasing);
-                        assert_eq!(increasing.shuffle_bytes(decreasing), decreasing);
-                        assert_eq!(decreasing.shuffle_bytes(decreasing), increasing);
+                        assert_eq!(increasing.shuffle_bytes(increasing), increasing, "(i,i)=>i");
+                        assert_eq!(decreasing.shuffle_bytes(increasing), decreasing, "(d,i)=>d");
+                        assert_eq!(increasing.shuffle_bytes(decreasing), decreasing, "(i,d)=>d");
+                        assert_eq!(decreasing.shuffle_bytes(decreasing), increasing, "(d,d)=>i");
 
                         for i in 0..$id::lanes() {
                             assert_eq!(increasing.shuffle_bytes($id::splat(i as $elem_ty)),

--- a/src/api/slice/from_slice.rs
+++ b/src/api/slice/from_slice.rs
@@ -15,7 +15,7 @@ macro_rules! impl_slice_from_slice {
                     assert!(slice.len() >= $elem_count);
                     let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
                     assert!(
-                        target_ptr.align_offset(::mem::align_of::<Self>())
+                        target_ptr.align_offset(mem::align_of::<Self>())
                             == 0
                     );
                     Self::from_slice_aligned_unchecked(slice)

--- a/src/codegen/shuffle_bytes.rs
+++ b/src/codegen/shuffle_bytes.rs
@@ -209,7 +209,10 @@ macro_rules! impl_shuffle_bytes {
                         use arch::x86::{_mm_permutevar_pd};
                         #[cfg(target_arch = "x86_64")]
                         use arch::x86_64::{_mm_permutevar_pd};
-
+                        // _mm_permutevar_pd uses the _second_ bit of each
+                        // element to perform the selection, that is: 0b00 => 0,
+                        // 0b10 => 1:
+                        let indices = indices << 1;
                         unsafe {
                             mem::transmute(_mm_permutevar_pd(
                                 mem::transmute(self), mem::transmute(indices))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,8 +246,8 @@ extern crate arrayvec;
 
 #[allow(unused_imports)]
 use core::{
-    cmp, default, f32, f64, fmt, hash, hint, intrinsics, iter, marker, mem,
-    ops, ptr, slice,
+    /* arch (handled above), */ cmp, default, f32, f64, fmt, hash, hint,
+    intrinsics, iter, marker, mem, ops, ptr, slice,
 };
 
 #[macro_use]


### PR DESCRIPTION
This PR improves the codegen for `shuffle_bytes` by:

* using`_mm_shuffle_pi8` for `u8x8` 
* using the permute ps/pd instructions suggested by @lemaitre for `u32x4` and `u64x2`

Closes #60 .

cc @TheIronBorn @lemaitre 