### PR TITLE
name travis builds; fail early if rustup target add fails

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,22 @@ environment:
   matrix:
     - TARGET: x86_64-pc-windows-msvc
       MSYSTEM: MINGW64
+    - TARGET: x86_64-pc-windows-msvc
+      MSYSTEM: MINGW64
+      RUSTFLAGS: "-C target-feature=+sse4.2"
+    - TARGET: x86_64-pc-windows-msvc
+      MSYSTEM: MINGW64
+      RUSTFLAGS: "-C target-feature=+avx2"
+
     - TARGET: i686-pc-windows-msvc
       MSYSTEM: MINGW32
+    - TARGET: i686-pc-windows-msvc
+      MSYSTEM: MINGW32
+      RUSTFLAGS: "-C target-feature=+sse4.2"
+    - TARGET: i686-pc-windows-msvc
+      MSYSTEM: MINGW32
+      RUSTFLAGS: "-C target-feature=+avx2"
+
     - TARGET: x86_64-pc-windows-gnu
       MSYSTEM: MINGW64
     - TARGET: i686-pc-windows-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,28 +7,65 @@ matrix:
   include:
     # Android:
     - env: TARGET=x86_64-linux-android
-      name: "x86_64-unknown-linux-android"
+      name: "x86_64-unknown-linux-android + SSE2"
     - env: TARGET=arm-linux-androideabi
       name: "arm-linux-androideabi"
+    - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
+      name: "arm-linux-androideabi + NEON"
+    - env: TARGET=aarch64-linux-android
+      name: "aarch64-unknown-linux-android"
+    - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
+      name: "aarch64-unknown-linux-android + NEON"
     # Linux:
     - env: TARGET=i586-unknown-linux-gnu
-      name: "i586-unknown-linux-gnu"
+      name: "i586-unknown-linux-gnu + SSE2"
+    - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "i586-unknown-linux-gnu + SSE4.2"
+    - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
+      name: "i586-unknown-linux-gnu + AVX2"
     - env: TARGET=i686-unknown-linux-gnu
-      name: "i686-unknown-linux-gnu"
+      name: "i686-unknown-linux-gnu + SSE2"
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "i686-unknown-linux-gnu + SSE4.2"
+    - env: TARGET=i686-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
+      name: "i686-unknown-linux-gnu + AVX2"
     - env: TARGET=x86_64-unknown-linux-gnu
-      name: "x86_64-unknown-linux-gnu"
+      name: "x86_64-unknown-linux-gnu + SSE2"
+      install: true
+    - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "x86_64-unknown-linux-gnu + SSE4.2"
+      install: true
+    - env: TARGET=x86_64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+avx2"
+      name: "x86_64-unknown-linux-gnu + AVX2"
       install: true
     - env: TARGET=x86_64-unknown-linux-gnu-emulated
-      name: "Intel Software Development Emulator"
+      name: "Intel SDE + SSE2"
+      install: true
+    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "Intel SDE + SSE4.2"
+      install: true
+    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+avx2"
+      name: "Intel SDE + AVX2"
+      install: true
+    - env: TARGET=x86_64-unknown-linux-gnu-emulated RUSTFLAGS="-C target-feature=+avx-512"
+      name: "Intel SDE + AVX-512"
       install: true
     - env: TARGET=arm-unknown-linux-gnueabi
       name: "arm-unknown-linux-gnueabi"
+    - env: TARGET=arm-unknown-linux-gnueabi RUSTFLAGS="-C target-feature=+v7,+neon"
+      name: "arm-unknown-linux-gnueabi + NEON"
     - env: TARGET=arm-unknown-linux-gnueabihf
       name: "arm-unknown-linux-gnueabihf"
+    - env: TARGET=arm-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+v7,+neon"
+      name: "arm-unknown-linux-gnueabihf + NEON"
     - env: TARGET=armv7-unknown-linux-gnueabihf
       name: "armv7-unknown-linux-gnueabihf"
+    - env: TARGET=armv7-unknown-linux-gnueabihf RUSTFLAGS="-C target-feature=+neon"
+      name: "armv7-unknown-linux-gnueabihf + NEON"
     - env: TARGET=aarch64-unknown-linux-gnu
       name: "aarch64-unknown-linux-gnu"
+    - env: TARGET=aarch64-unknown-linux-gnu RUSTFLAGS="-C target-feature=+neon"
+      name: "aarch64-unknown-linux-gnu + NEON"
     - env: TARGET=mips-unknown-linux-gnu
       name: "mips-unknown-linux-gnu"
     - env: TARGET=mipsel-unknown-linux-musl
@@ -37,12 +74,18 @@ matrix:
       name: "mips64-unknown-linux-gnuabi64"
     - env: TARGET=mips64el-unknown-linux-gnuabi64
       name: "mips64el-unknown-linux-gnuabi64"
+      # FIXME: https://github.com/rust-lang-nursery/packed_simd/issues/18
+      # env: TARGET=mips64el-unknown-linux-gnuabi64 RUSTFLAGS="-C target-feature=+msa -C target-cpu=mips64r6"
     - env: TARGET=powerpc-unknown-linux-gnu
       name: "powerpc-unknown-linux-gnu"
     - env: TARGET=powerpc64-unknown-linux-gnu
       name: "powerpc64-unknown-linux-gnu"
     - env: TARGET=powerpc64le-unknown-linux-gnu
       name: "powerpc64le-unknown-linux-gnu"
+    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+altivec"
+      name: "powerpc64le-unknown-linux-gnu + ALTIVEC"
+    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+vsx"
+      name: "powerpc64le-unknown-linux-gnu + VSX"
     - env: TARGET=s390x-unknown-linux-gnu
       name: "s390x-unknown-linux-gnu"
     - env: TARGET=sparc64-unknown-linux-gnu
@@ -50,12 +93,23 @@ matrix:
     # MacOSX:
     - os: osx
       env: TARGET=i686-apple-darwin
-      name: "i686-apple-darwin"
+      name: "i686-apple-darwin + SSE2"
+      script: ci/run.sh
+      osx_image: xcode9.4
+    - os: osx
+      env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "i686-apple-darwin + SSE4.2"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
       env: TARGET=x86_64-apple-darwin
-      name: "x86_64-apple-darwin"
+      name: "x86_64-apple-darwin + SSE2"
+      install: true
+      script: ci/run.sh
+      osx_image: xcode9.4
+    - os: osx
+      env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
+      name: "x86_64-apple-darwin + SSE4.2"
       install: true
       script: ci/run.sh
       osx_image: xcode9.4
@@ -77,7 +131,7 @@ matrix:
       osx_image: xcode9.4
     - os: osx
       env: TARGET=x86_64-apple-ios
-      name: "x86_64-apple-ios"
+      name: "x86_64-apple-ios + SSE2"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
@@ -114,6 +168,8 @@ matrix:
     - env: TARGET=powerpc-unknown-linux-gnu
     - env: TARGET=powerpc64-unknown-linux-gnu
     - env: TARGET=powerpc64le-unknown-linux-gnu
+    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+altivec"
+    - env: TARGET=powerpc64le-unknown-linux-gnu RUSTFLAGS="-C target-feature=+vsx"
     #- env: TARGET=i686-unknown-freebsd NORUN=1
     #- env: TARGET=x86_64-unknown-freebsd NORUN=1
     #- env: TARGET=x86_64-unknown-netbsd NORUN=1
@@ -121,7 +177,9 @@ matrix:
 
     # FIXME: TBD
     - env: TARGET=arm-linux-androideabi
+    - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"
     - env: TARGET=aarch64-linux-android
+    - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
 
     # FIXME: iOS
     # https://github.com/rust-lang-nursery/packed_simd/issues/26
@@ -132,7 +190,7 @@ install:
   - rustup target add $TARGET
 script:
   - cargo generate-lockfile
-  - travis_wait 60 ci/run-docker.sh $TARGET $FEATURES
+  - travis_wait 40 ci/run-docker.sh $TARGET $FEATURES
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       name: "x86_64-unknown-linux-gnu"
       install: true
     - env: TARGET=x86_64-unknown-linux-gnu-emulated
-      name: "Intel SDE 8.16.0"
+      name: "Intel Software Development Emulator"
       install: true
     - env: TARGET=arm-unknown-linux-gnueabi
       name: "arm-unknown-linux-gnueabi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,8 +186,7 @@ matrix:
     - env: TARGET=i386-apple-ios
     - env: TARGET=x86_64-apple-ios
 
-install:
-  - rustup target add $TARGET
+install: travis_retry rustup target add $TARGET
 script:
   - cargo generate-lockfile
   - travis_wait 40 ci/run-docker.sh $TARGET $FEATURES

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,14 +102,7 @@ matrix:
       install: true
       before_script:
       - rustup component add rustfmt-preview
-      script:
-      - cargo fmt --all -- --check
-      - |
-        for dir in examples/*/
-        do
-            dir=${dir%*/}
-            cd ${dir%*/} && cargo fmt --all -- --check && cd -
-        done
+      script: ci/check_fmt.sh
     - name: "clippy"
       install: true
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,43 +7,56 @@ matrix:
   include:
     # Android:
     - env: TARGET=x86_64-linux-android
+      name: "x86_64-unknown-linux-android"
     - env: TARGET=arm-linux-androideabi
-      install:
-        - rustup target add $TARGET || true
-      script:
-        - cargo generate-lockfile
-        - travis_wait 50 ci/run-docker.sh $TARGET $FEATURES
-    - env: TARGET=aarch64-linux-android
-      install:
-        - rustup target add $TARGET || true
-      script:
-        - cargo generate-lockfile
-        - travis_wait 50 ci/run-docker.sh $TARGET $FEATURES
+      name: "arm-linux-androideabi"
     # Linux:
     - env: TARGET=i586-unknown-linux-gnu
+      name: "i586-unknown-linux-gnu"
     - env: TARGET=i686-unknown-linux-gnu
+      name: "i686-unknown-linux-gnu"
     - env: TARGET=x86_64-unknown-linux-gnu
+      name: "x86_64-unknown-linux-gnu"
+      install: true
     - env: TARGET=x86_64-unknown-linux-gnu-emulated
+      name: "Intel SDE 8.16.0"
+      install: true
     - env: TARGET=arm-unknown-linux-gnueabi
+      name: "arm-unknown-linux-gnueabi"
     - env: TARGET=arm-unknown-linux-gnueabihf
+      name: "arm-unknown-linux-gnueabihf"
     - env: TARGET=armv7-unknown-linux-gnueabihf
+      name: "armv7-unknown-linux-gnueabihf"
     - env: TARGET=aarch64-unknown-linux-gnu
+      name: "aarch64-unknown-linux-gnu"
     - env: TARGET=mips-unknown-linux-gnu
+      name: "mips-unknown-linux-gnu"
     - env: TARGET=mipsel-unknown-linux-musl
+      name: "mipsel-unknown-linux-musl"
     - env: TARGET=mips64-unknown-linux-gnuabi64
+      name: "mips64-unknown-linux-gnuabi64"
     - env: TARGET=mips64el-unknown-linux-gnuabi64
+      name: "mips64el-unknown-linux-gnuabi64"
     - env: TARGET=powerpc-unknown-linux-gnu
+      name: "powerpc-unknown-linux-gnu"
     - env: TARGET=powerpc64-unknown-linux-gnu
+      name: "powerpc64-unknown-linux-gnu"
     - env: TARGET=powerpc64le-unknown-linux-gnu
+      name: "powerpc64le-unknown-linux-gnu"
     - env: TARGET=s390x-unknown-linux-gnu
+      name: "s390x-unknown-linux-gnu"
     - env: TARGET=sparc64-unknown-linux-gnu
+      name: "sparc64-unknown-linux-gnu"
     # MacOSX:
     - os: osx
       env: TARGET=i686-apple-darwin
+      name: "i686-apple-darwin"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
       env: TARGET=x86_64-apple-darwin
+      name: "x86_64-apple-darwin"
+      install: true
       script: ci/run.sh
       osx_image: xcode9.4
     # *BSDs:
@@ -59,28 +72,34 @@ matrix:
     # iOS: 
     - os: osx
       env: TARGET=i386-apple-ios
+      name: "i386-apple-ios"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
       env: TARGET=x86_64-apple-ios
+      name: "x86_64-apple-ios"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
       env: TARGET=armv7-apple-ios NORUN=1
+      name: "armv7-apple-ios [BUILD only]"
       script: ci/run.sh
       osx_image: xcode9.4
     - os: osx
       env: TARGET=aarch64-apple-ios NORUN=1
+      name: "aarch64-apple-ios [BUILD only]"
       script: ci/run.sh
       osx_image: xcode9.4
     # WASM:
     - env: TARGET=wasm32-unknown-unknown NORUN=1
+      name: "wasm32-unknown-unknown [BUILD only]"
       script: ci/run.sh
     # TOOLS:
-    - env: DOCUMENTATION
+    - name: "Documentation"
       install: true
       script: ci/dox.sh
-    - env: RUSTFMT=On TARGET=x86_64-unknown-linux-gnu
+    - name: "rustfmt"
+      install: true
       before_script:
       - rustup component add rustfmt-preview
       script:
@@ -91,7 +110,8 @@ matrix:
             dir=${dir%*/}
             cd ${dir%*/} && cargo fmt --all -- --check && cd -
         done
-    - env: CLIPPY=On TARGET=x86_64-unknown-linux-gnu
+    - name: "clippy"
+      install: true
       before_script:
       - rustup component add clippy-preview
       script:
@@ -117,11 +137,10 @@ matrix:
     - env: TARGET=x86_64-apple-ios
 
 install:
-  - rustup target add $TARGET || true
-
+  - rustup target add $TARGET
 script:
   - cargo generate-lockfile
-  - ci/run-docker.sh $TARGET $FEATURES
+  - travis_wait 60 ci/run-docker.sh $TARGET $FEATURES
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,7 @@ matrix:
       install: true
       before_script:
       - rustup component add clippy-preview
-      script:
-      - cargo clippy --all -- -D clippy-pedantic
+      script: ci/check_clippy.sh
 
   allow_failures:
     # FIXME: TBD

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,12 @@ matrix:
       name: "i686-apple-darwin + SSE4.2"
       script: ci/run.sh
       osx_image: xcode9.4
+      # Travis-CI OSX build bots do not support AVX2:
+    - os: osx
+      env: TARGET=i686-apple-darwin RUSTFLAGS="-C target-feature=+avx"
+      name: "i686-apple-darwin + AVX"
+      script: ci/run.sh
+      osx_image: xcode9.4
     - os: osx
       env: TARGET=x86_64-apple-darwin
       name: "x86_64-apple-darwin + SSE2"
@@ -110,6 +116,13 @@ matrix:
     - os: osx
       env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+sse4.2"
       name: "x86_64-apple-darwin + SSE4.2"
+      install: true
+      script: ci/run.sh
+      osx_image: xcode9.4
+      # Travis-CI OSX build bots do not support AVX2:
+    - os: osx
+      env: TARGET=x86_64-apple-darwin RUSTFLAGS="-C target-feature=+avx"
+      name: "x86_64-apple-darwin + AVX"
       install: true
       script: ci/run.sh
       osx_image: xcode9.4

--- a/ci/check_clippy.sh
+++ b/ci/check_clippy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Uses clippy to check the idioms of the library
+
+set -ex
+
+cargo_clippy() {
+    cargo clippy --all -- -D clippy-pedantic
+}
+
+# Check src/
+cargo_clippy
+
+# Check examples/
+for dir in examples/*/
+do
+    dir=${dir%*/}
+    cd ${dir%*/}
+    cargo_clippy
+    cd -
+done

--- a/ci/check_fmt.sh
+++ b/ci/check_fmt.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Uses rustfmt to check the formatting of the library
+
+set -ex
+
+cargo_fmt() {
+    cargo fmt --all -- --check
+}
+
+# Check src/
+cargo_fmt
+
+# Check examples/
+for dir in examples/*/
+do
+    dir=${dir%*/}
+    cd ${dir%*/}
+    cargo_fmt
+    cd -
+done

--- a/ci/dox.sh
+++ b/ci/dox.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-set -e
+set -ex
 
 rm -rf target/doc
 mkdir -p target/doc
 
-cargo doc
+cargo doc --features=into_bits
 
 # If we're on travis, not a PR, and on the right branch, publish!
 if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -58,6 +58,7 @@ cargo_test_impl() {
 }
 
 cargo_test_impl
+cargo_test_impl "--release --features=into_bits"
 cargo_test_impl "--release --features=into_bits,coresimd"
 
 # Examples - the source directory is read-only.

--- a/examples/aobench/benches/isec_plane.rs
+++ b/examples/aobench/benches/isec_plane.rs
@@ -9,7 +9,7 @@ extern crate criterion;
 use criterion::*;
 
 use aobench_lib::*;
-use geometry::{f32xN, Plane, Ray, RayxN, V3D, V3DxN};
+use geometry::{f32xN, Plane, Ray, RayxN, V3DxN, V3D};
 use intersection::{Intersect, Isect, IsectxN};
 
 fn hit_scalar(c: &mut Criterion) {

--- a/examples/aobench/benches/isec_sphere.rs
+++ b/examples/aobench/benches/isec_sphere.rs
@@ -8,7 +8,7 @@ extern crate criterion;
 
 use aobench_lib::*;
 use criterion::*;
-use geometry::{f32xN, Ray, RayxN, Sphere, V3D, V3DxN};
+use geometry::{f32xN, Ray, RayxN, Sphere, V3DxN, V3D};
 use intersection::{Intersect, Isect, IsectxN};
 
 fn hit_scalar(c: &mut Criterion) {

--- a/examples/aobench/src/ambient_occlusion.rs
+++ b/examples/aobench/src/ambient_occlusion.rs
@@ -29,7 +29,7 @@ pub fn scalar<S: Scene>(scene: &mut S, isect: &Isect) -> f32 {
             let dir = basis * n;
             let ray = Ray { origin, dir };
 
-            let mut occ_isect = Isect::new();
+            let mut occ_isect = Isect::default();
             for s in scene.spheres() {
                 occ_isect = ray.intersect(s, occ_isect);
             }
@@ -73,7 +73,7 @@ pub fn vector<S: Scene>(scene: &mut S, isect: &Isect) -> f32 {
             let dir = basis * n;
             let ray = RayxN { origin, dir };
 
-            let mut occ_isect = IsectxN::new();
+            let mut occ_isect = IsectxN::default();
             for s in scene.spheres() {
                 occ_isect = ray.intersect(s, occ_isect);
             }
@@ -93,18 +93,18 @@ mod tests {
 
     #[test]
     fn sanity_hit() {
-        let scene = ::scene::Test::new();
+        let scene = ::scene::Test::default();
         let mut scene_scalar = scene.clone();
         let mut scene_vector = scene.clone();
         let ray = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: -0.2,
                 y: -0.2,
                 z: -0.2,
             },
         };
-        let mut isect = Isect::new();
+        let mut isect = Isect::default();
 
         for s in scene.spheres() {
             isect = ray.intersect(s, isect);
@@ -120,19 +120,19 @@ mod tests {
 
     #[test]
     fn sanity_miss() {
-        let scene = ::scene::Test::new();
+        let scene = ::scene::Test::default();
         let mut scene_scalar = scene.clone();
         let mut scene_vector = scene.clone();
 
         let ray = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: 0.2,
                 y: 0.2,
                 z: 0.2,
             },
         };
-        let mut isect = Isect::new();
+        let mut isect = Isect::default();
 
         for s in scene.spheres() {
             isect = ray.intersect(s, isect);

--- a/examples/aobench/src/ambient_occlusion.rs
+++ b/examples/aobench/src/ambient_occlusion.rs
@@ -1,6 +1,6 @@
 //! Ambient Occlusion implementations
 
-use geometry::{f32xN, Ray, RayxN, Selectable, V3D, V3DxN};
+use geometry::{f32xN, Ray, RayxN, Selectable, V3DxN, V3D};
 use intersection::{Intersect, Isect, IsectxN};
 use scene::Scene;
 use std::f32::consts::PI;

--- a/examples/aobench/src/geometry/vec.rs
+++ b/examples/aobench/src/geometry/vec.rs
@@ -9,19 +9,21 @@ pub struct V3D {
     pub z: f32,
 }
 
-pub type M3x3 = [V3D; 3];
-
-impl V3D {
+impl Default for V3D {
     #[inline(always)]
     #[must_use]
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             x: 0.,
             y: 0.,
             z: 0.,
         }
     }
+}
 
+pub type M3x3 = [V3D; 3];
+
+impl V3D {
     #[inline(always)]
     #[must_use]
     pub fn cross(self, o: Self) -> Self {
@@ -40,7 +42,7 @@ impl V3D {
     #[must_use]
     pub fn ortho_basis(self) -> M3x3 {
         let n = self;
-        let mut basis = [V3D::new(), V3D::new(), n];
+        let mut basis = [Self::default(), Self::default(), n];
 
         if n.x < 0.6 && n.x > -0.6 {
             basis[1].x = 1.0;
@@ -62,7 +64,7 @@ impl Add for V3D {
     type Output = Self;
     #[inline(always)]
     fn add(self, o: Self) -> Self::Output {
-        V3D {
+        Self {
             x: self.x + o.x,
             y: self.y + o.y,
             z: self.z + o.z,
@@ -74,7 +76,7 @@ impl Sub for V3D {
     type Output = Self;
     #[inline(always)]
     fn sub(self, o: Self) -> Self::Output {
-        V3D {
+        Self {
             x: self.x - o.x,
             y: self.y - o.y,
             z: self.z - o.z,
@@ -85,7 +87,7 @@ impl Sub for V3D {
 impl Mul for V3D {
     type Output = Self;
     fn mul(self, o: Self) -> Self::Output {
-        V3D {
+        Self {
             x: self.x * o.x,
             y: self.y * o.y,
             z: self.z * o.z,
@@ -97,7 +99,7 @@ impl Mul<f32> for V3D {
     type Output = Self;
     #[inline(always)]
     fn mul(self, o: f32) -> Self::Output {
-        V3D {
+        Self {
             x: self.x * o,
             y: self.y * o,
             z: self.z * o,
@@ -146,7 +148,7 @@ pub trait Dot<O> {
 impl Dot<V3D> for V3D {
     type Output = f32;
     #[inline(always)]
-    fn dot(self, o: V3D) -> Self::Output {
+    fn dot(self, o: Self) -> Self::Output {
         self.x * o.x + self.y * o.y + self.z * o.z
     }
 }

--- a/examples/aobench/src/geometry/vecxN.rs
+++ b/examples/aobench/src/geometry/vecxN.rs
@@ -11,16 +11,19 @@ pub struct V3DxN {
     pub z: f32xN,
 }
 
-impl V3DxN {
+impl Default for V3DxN {
     #[inline(always)]
     #[must_use]
-    pub fn new() -> Self {
+    fn default() -> Self {
         Self {
             x: f32xN::splat(0.),
             y: f32xN::splat(0.),
             z: f32xN::splat(0.),
         }
     }
+}
+
+impl V3DxN {
     #[inline(always)]
     #[must_use]
     pub fn normalized(self) -> Self {
@@ -37,9 +40,9 @@ impl V3DxN {
 
     #[must_use]
     #[inline(always)]
-    pub fn ortho_basis(self) -> [V3DxN; 3] {
+    pub fn ortho_basis(self) -> [Self; 3] {
         let n = self;
-        let mut basis = [V3DxN::new(), V3DxN::new(), n];
+        let mut basis = [Self::default(), Self::default(), n];
 
         let max = f32xN::splat(0.6);
         let min = f32xN::splat(-0.6);
@@ -73,7 +76,7 @@ impl Add for V3DxN {
     type Output = Self;
     #[inline(always)]
     fn add(self, o: Self) -> Self::Output {
-        V3DxN {
+        Self {
             x: self.x + o.x,
             y: self.y + o.y,
             z: self.z + o.z,
@@ -85,7 +88,7 @@ impl Mul for V3DxN {
     type Output = Self;
     #[inline(always)]
     fn mul(self, o: Self) -> Self::Output {
-        V3DxN {
+        Self {
             x: self.x * o.x,
             y: self.y * o.y,
             z: self.z * o.z,
@@ -109,7 +112,7 @@ impl Sub<V3D> for V3DxN {
     type Output = Self;
     #[inline(always)]
     fn sub(self, o: V3D) -> Self::Output {
-        V3DxN {
+        Self {
             x: self.x - f32xN::splat(o.x),
             y: self.y - f32xN::splat(o.y),
             z: self.z - f32xN::splat(o.z),
@@ -120,7 +123,7 @@ impl Sub<V3D> for V3DxN {
 impl Dot<V3DxN> for V3DxN {
     type Output = f32xN;
     #[inline(always)]
-    fn dot(self, o: V3DxN) -> Self::Output {
+    fn dot(self, o: Self) -> Self::Output {
         self.x * o.x + self.y * o.y + self.z * o.z
     }
 }

--- a/examples/aobench/src/intersection/packet.rs
+++ b/examples/aobench/src/intersection/packet.rs
@@ -12,15 +12,19 @@ pub struct IsectxN {
     pub hit: m32xN,
 }
 
-impl IsectxN {
-    pub fn new() -> Self {
+impl Default for IsectxN {
+    #[inline]
+    fn default() -> Self {
         Self {
-            t: f32xN::splat(1.0e+17),
+            t: f32xN::splat(1e17),
             hit: m32xN::splat(false),
-            p: V3DxN::new(),
-            n: V3DxN::new(),
+            p: V3DxN::default(),
+            n: V3DxN::default(),
         }
     }
+}
+
+impl IsectxN {
     pub fn get(&self, idx: usize) -> Isect {
         Isect {
             t: self.t.extract(idx),

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -90,7 +90,7 @@ mod tests {
         };
 
         let ray_hit = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: 0.01,
                 y: 0.01,
@@ -98,7 +98,7 @@ mod tests {
             },
         };
         let ray_miss = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: 0.,
                 y: 0.,
@@ -106,9 +106,9 @@ mod tests {
             },
         };
 
-        let isect_hit = ray_hit.intersect(&plane, Isect::new());
+        let isect_hit = ray_hit.intersect(&plane, Isect::default());
         assert!(isect_hit.hit);
-        let isect_miss = ray_miss.intersect(&plane, Isect::new());
+        let isect_miss = ray_miss.intersect(&plane, Isect::default());
         assert!(!isect_miss.hit);
 
         // hit, miss, hit, miss
@@ -119,7 +119,7 @@ mod tests {
         let z_val = f32xN::new(-1., 1., -1., 1.);
 
         let rays = RayxN {
-            origin: V3DxN::new(),
+            origin: V3DxN::default(),
             dir: V3DxN {
                 x: f32xN::splat(0.01),
                 y: f32xN::splat(0.01),
@@ -127,7 +127,7 @@ mod tests {
             },
         };
 
-        let isectxN = rays.intersect(&plane, IsectxN::new());
+        let isectxN = rays.intersect(&plane, IsectxN::default());
 
         #[cfg(feature = "256bit")]
         let expected =

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -12,7 +12,7 @@ impl Intersect<Plane> for Ray {
         let d = -plane.p.dot(plane.n);
         let v = ray.dir.dot(plane.n);
 
-        if v.abs() < 1.0e-17 {
+        if v.abs() < 1e-17 {
             return isect;
         }
 
@@ -40,14 +40,14 @@ impl Intersect<Plane> for RayxN {
 
         let old_isect = isect;
 
-        let m = v.abs().ge(f32xN::splat(1.0e-17));
+        let m = v.abs().ge(f32xN::splat(1e-17));
         if m.any() {
             let t = m.sel(-(ray.origin.dot(plane.n) + d) / v, isect.t);
             let m = m & t.gt(f32xN::splat(0.)) & t.lt(isect.t);
 
             if m.any() {
                 isect.t = m.sel(t, isect.t);
-                isect.hit = m | isect.hit;
+                isect.hit |= m;
                 isect.p = m.sel(ray.origin + t * ray.dir, isect.p);
                 isect.n = m.sel(plane.n, isect.n);
             }

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -72,7 +72,7 @@ impl Intersect<Plane> for RayxN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geometry::{m32xN, V3D, V3DxN};
+    use geometry::{m32xN, V3DxN, V3D};
 
     #[test]
     fn sanity() {

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -51,7 +51,7 @@ impl Intersect<Sphere> for RayxN {
 
             if m.any() {
                 isect.t = m.sel(t, isect.t);
-                isect.hit = m | isect.hit;
+                isect.hit |= m;
                 isect.p = m.sel(ray.origin + t * ray.dir, isect.p);
                 isect.n =
                     m.sel((isect.p - sphere.center).normalized(), isect.n);

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -77,7 +77,7 @@ impl Intersect<Sphere> for RayxN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geometry::{m32xN, V3D, V3DxN};
+    use geometry::{m32xN, V3DxN, V3D};
 
     #[test]
     fn sanity() {

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -91,7 +91,7 @@ mod tests {
         };
 
         let ray_hit = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: 0.01,
                 y: 0.01,
@@ -99,7 +99,7 @@ mod tests {
             },
         };
         let ray_miss = Ray {
-            origin: V3D::new(),
+            origin: V3D::default(),
             dir: V3D {
                 x: 0.,
                 y: 0.,
@@ -107,9 +107,9 @@ mod tests {
             },
         };
 
-        let isect_hit = ray_hit.intersect(&sphere, Isect::new());
+        let isect_hit = ray_hit.intersect(&sphere, Isect::default());
         assert!(isect_hit.hit);
-        let isect_miss = ray_miss.intersect(&sphere, Isect::new());
+        let isect_miss = ray_miss.intersect(&sphere, Isect::default());
         assert!(!isect_miss.hit);
 
         // hit, miss, hit, miss
@@ -119,7 +119,7 @@ mod tests {
         let z_val = f32xN::new(-1., 1., -1., 1.);
 
         let rays = RayxN {
-            origin: V3DxN::new(),
+            origin: V3DxN::default(),
             dir: V3DxN {
                 x: f32xN::splat(0.01),
                 y: f32xN::splat(0.01),
@@ -127,7 +127,7 @@ mod tests {
             },
         };
 
-        let isectxN = rays.intersect(&sphere, IsectxN::new());
+        let isectxN = rays.intersect(&sphere, IsectxN::default());
 
         #[cfg(feature = "256bit")]
         let expected =

--- a/examples/aobench/src/intersection/single.rs
+++ b/examples/aobench/src/intersection/single.rs
@@ -11,13 +11,14 @@ pub struct Isect {
     pub hit: bool,
 }
 
-impl Isect {
-    pub fn new() -> Self {
+impl Default for Isect {
+    #[inline]
+    fn default() -> Self {
         Self {
-            t: 1.0e+17,
+            t: 1e17,
             hit: false,
-            p: V3D::new(),
-            n: V3D::new(),
+            p: V3D::default(),
+            n: V3D::default(),
         }
     }
 }

--- a/examples/aobench/src/lib.rs
+++ b/examples/aobench/src/lib.rs
@@ -1,8 +1,21 @@
 //! aobench: Ambient Occlusion Renderer benchmark.
 //!
-//! Based on: https://code.google.com/archive/p/aobench/
-
+//! Based on [aobench](https://code.google.com/archive/p/aobench/) by Syoyo
+//! Fujita.
+#![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types)]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        many_single_char_names,
+        similar_names,
+        cast_precision_loss,
+        inline_always,
+        cast_possible_truncation,
+        cast_sign_loss,
+        identity_op
+    )
+)]
 
 #[macro_use]
 extern crate cfg_if;

--- a/examples/aobench/src/main.rs
+++ b/examples/aobench/src/main.rs
@@ -1,6 +1,8 @@
 //! aobench: Ambient Occlusion Renderer benchmark.
 //!
-//! Based on: https://code.google.com/archive/p/aobench/
+//! Based on [aobench](https://code.google.com/archive/p/aobench/) by Syoyo
+//! Fujita.
+#![deny(warnings)]
 
 #[macro_use]
 extern crate structopt;
@@ -30,15 +32,16 @@ struct Opt {
 
 fn main() {
     let opt = Opt::from_args();
-    let mut scene = aobench_lib::scene::Random::new();
+    let mut scene = aobench_lib::scene::Random::default();
     let mut img = Image::new(opt.width, opt.height);
 
     let d = match opt.algo.as_str() {
         "scalar" => {
             let d =
                 time::Duration::span(|| scalar::ao(&mut scene, 2, &mut img));
-            let image_path =
-                opt.output.unwrap_or(PathBuf::from("image_scalar.png"));
+            let image_path = opt
+                .output
+                .unwrap_or_else(|| PathBuf::from("image_scalar.png"));
             img.write_png(&image_path, false)
                 .expect("failed to write image");
             d
@@ -47,8 +50,9 @@ fn main() {
             let d = time::Duration::span(|| {
                 scalar_parallel::ao(&mut scene, 2, &mut img)
             });
-            let image_path =
-                opt.output.unwrap_or(PathBuf::from("image_scalar_par.png"));
+            let image_path = opt
+                .output
+                .unwrap_or_else(|| PathBuf::from("image_scalar_par.png"));
             img.write_png(&image_path, false)
                 .expect("failed to write image");
             d
@@ -56,8 +60,9 @@ fn main() {
         "vector" => {
             let d =
                 time::Duration::span(|| vector::ao(&mut scene, 2, &mut img));
-            let image_path =
-                opt.output.unwrap_or(PathBuf::from("image_vector.png"));
+            let image_path = opt
+                .output
+                .unwrap_or_else(|| PathBuf::from("image_vector.png"));
             img.write_png(&image_path, false)
                 .expect("failed to write image");
             d
@@ -66,8 +71,9 @@ fn main() {
             let d = time::Duration::span(|| {
                 vector_parallel::ao(&mut scene, 2, &mut img)
             });
-            let image_path =
-                opt.output.unwrap_or(PathBuf::from("image_vector_par.png"));
+            let image_path = opt
+                .output
+                .unwrap_or_else(|| PathBuf::from("image_vector_par.png"));
             img.write_png(&image_path, false)
                 .expect("failed to write image");
             d

--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -19,31 +19,31 @@ pub mod scalar {
     impl RngT {
         fn from_seed(x: u32) -> Self {
             let z0 = x;
-            let z1 = x ^ 0xbeeff00d;
+            let z1 = x ^ 0xbeef_f00d;
             let z2 = ((x & 0xffff_u32) << 16) | (x >> 16);
             let z3 = ((x & 0xff_u32) << 24)
                 | ((x & 0xff00_u32) << 8)
-                | ((x & 0xff0000_u32) >> 8)
-                | (x & 0xff000000_u32) >> 24;
+                | ((x & 0x00ff_0000_u32) >> 8)
+                | (x & 0xff00_0000_u32) >> 24;
             RngT(z0, z1, z2, z3)
         }
 
         pub fn gen_u32(&mut self) -> u32 {
             let mut b = ((self.0 << 6) ^ self.0) >> 13;
-            self.0 = ((self.0 & 4294967294_u32) << 18) ^ b;
+            self.0 = ((self.0 & 4_294_967_294_u32) << 18) ^ b;
             b = ((self.1 << 2) ^ self.1) >> 27;
-            self.1 = ((self.1 & 4294967288_u32) << 2) ^ b;
+            self.1 = ((self.1 & 4_294_967_288_u32) << 2) ^ b;
             b = ((self.2 << 13) ^ self.2) >> 21;
-            self.2 = ((self.2 & 4294967280_u32) << 7) ^ b;
+            self.2 = ((self.2 & 4_294_967_280_u32) << 7) ^ b;
             b = ((self.3 << 3) ^ self.3) >> 12;
-            self.3 = ((self.3 & 4294967168_u32) << 13) ^ b;
+            self.3 = ((self.3 & 4_294_967_168_u32) << 13) ^ b;
             self.0 ^ self.1 ^ self.2 ^ self.3
         }
 
         pub fn gen(&mut self) -> f32 {
             let mut v = self.gen_u32();
             v &= (1_u32 << 23) - 1;
-            let v: f32 = unsafe { ::std::mem::transmute(0x3F800000 | v) };
+            let v = f32::from_bits(0x3F80_0000 | v);
             v - 1.
         }
     }
@@ -82,32 +82,33 @@ pub mod vector {
     impl RngT {
         fn from_seed(x: u32xN) -> Self {
             let z0 = x;
-            let z1 = x ^ u32xN::splat(0xbeeff00d);
+            let z1 = x ^ u32xN::splat(0xbeef_f00d);
             let z2 = ((x & u32xN::splat(0xffff)) << 16) | (x >> 16);
             let z3 = ((x & u32xN::splat(0xff)) << 24)
                 | ((x & u32xN::splat(0xff00)) << 8)
-                | ((x & u32xN::splat(0xff0000)) >> 8)
-                | (x & u32xN::splat(0xff000000)) >> 24;
+                | ((x & u32xN::splat(0x00ff_0000)) >> 8)
+                | (x & u32xN::splat(0xff00_0000)) >> 24;
             RngT(z0, z1, z2, z3)
         }
 
         pub fn gen_u32(&mut self) -> u32xN {
             let mut b = ((self.0 << 6) ^ self.0) >> 13;
-            self.0 = ((self.0 & u32xN::splat(4294967294)) << 18) ^ b;
+            self.0 = ((self.0 & u32xN::splat(4_294_967_294)) << 18) ^ b;
             b = ((self.1 << 2) ^ self.1) >> 27;
-            self.1 = ((self.1 & u32xN::splat(4294967288)) << 2) ^ b;
+            self.1 = ((self.1 & u32xN::splat(4_294_967_288)) << 2) ^ b;
             b = ((self.2 << 13) ^ self.2) >> 21;
-            self.2 = ((self.2 & u32xN::splat(4294967280)) << 7) ^ b;
+            self.2 = ((self.2 & u32xN::splat(4_294_967_280)) << 7) ^ b;
             b = ((self.3 << 3) ^ self.3) >> 12;
-            self.3 = ((self.3 & u32xN::splat(4294967168)) << 13) ^ b;
+            self.3 = ((self.3 & u32xN::splat(4_294_967_168)) << 13) ^ b;
             self.0 ^ self.1 ^ self.2 ^ self.3
         }
 
         pub fn gen(&mut self) -> f32xN {
             let mut v = self.gen_u32();
             v &= u32xN::splat((1_u32 << 23) - 1);
-            let v: f32xN =
-                unsafe { ::std::mem::transmute(u32xN::splat(0x3F800000) | v) };
+            let v: f32xN = unsafe {
+                ::std::mem::transmute(u32xN::splat(0x3F80_0000) | v)
+            };
             v - f32xN::splat(1.)
         }
     }

--- a/examples/aobench/src/scalar.rs
+++ b/examples/aobench/src/scalar.rs
@@ -26,11 +26,11 @@ pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
                     let dir = dir.normalized();
 
                     let ray = Ray {
-                        origin: V3D::new(),
+                        origin: V3D::default(),
                         dir,
                     };
 
-                    let mut isect = Isect::new();
+                    let mut isect = Isect::default();
                     for s in scene.spheres() {
                         isect = ray.intersect(s, isect);
                     }

--- a/examples/aobench/src/scalar_parallel.rs
+++ b/examples/aobench/src/scalar_parallel.rs
@@ -16,7 +16,7 @@ pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
         let image = unsafe {
             ::std::slice::from_raw_parts_mut(image_ptr as *mut f32, image_len)
         };
-        let mut scene = S::new();
+        let mut scene = S::default();
         for x in 0..w {
             let offset = 3 * (y * w + x);
             for u in 0..ns {
@@ -33,11 +33,11 @@ pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
                     let dir = dir.normalized();
 
                     let ray = Ray {
-                        origin: V3D::new(),
+                        origin: V3D::default(),
                         dir,
                     };
 
-                    let mut isect = Isect::new();
+                    let mut isect = Isect::default();
                     for s in scene.spheres() {
                         isect = ray.intersect(s, isect);
                     }

--- a/examples/aobench/src/scene/mod.rs
+++ b/examples/aobench/src/scene/mod.rs
@@ -1,9 +1,8 @@
 /// Scene interface
 use geometry::{f32xN, Plane, Sphere};
 
-pub trait Scene: Send + Sync {
+pub trait Scene: Send + Sync + Default {
     const NAO_SAMPLES: usize;
-    fn new() -> Self;
     fn rand(&mut self) -> f32;
     fn plane(&self) -> &Plane;
     fn spheres(&self) -> &[Sphere];

--- a/examples/aobench/src/scene/random.rs
+++ b/examples/aobench/src/scene/random.rs
@@ -9,9 +9,8 @@ pub struct Random {
     pub spheres: [Sphere; 3],
 }
 
-impl Scene for Random {
-    const NAO_SAMPLES: usize = 8;
-    fn new() -> Self {
+impl Default for Random {
+    fn default() -> Self {
         let plane = Plane {
             p: V3D {
                 x: 0.,
@@ -52,6 +51,10 @@ impl Scene for Random {
         ];
         Self { plane, spheres }
     }
+}
+
+impl Scene for Random {
+    const NAO_SAMPLES: usize = 8;
     fn rand(&mut self) -> f32 {
         ::random::scalar::thread_rng().gen()
     }

--- a/examples/aobench/src/scene/test.rs
+++ b/examples/aobench/src/scene/test.rs
@@ -12,9 +12,8 @@ pub struct Test {
     rand_step: Wrapping<usize>,
 }
 
-impl Scene for Test {
-    const NAO_SAMPLES: usize = 8;
-    fn new() -> Self {
+impl Default for Test {
+    fn default() -> Self {
         let plane = Plane {
             p: V3D {
                 x: 0.,
@@ -66,6 +65,10 @@ impl Scene for Test {
             rand_step,
         }
     }
+}
+
+impl Scene for Test {
+    const NAO_SAMPLES: usize = 8;
     fn rand(&mut self) -> f32 {
         let v = self.rands[self.rand_step.0];
         self.rand_step += Wrapping(1);

--- a/examples/aobench/src/vector.rs
+++ b/examples/aobench/src/vector.rs
@@ -27,11 +27,11 @@ fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
                     let dir = dir.normalized();
 
                     let ray = Ray {
-                        origin: V3D::new(),
+                        origin: V3D::default(),
                         dir,
                     };
 
-                    let mut isect = Isect::new();
+                    let mut isect = Isect::default();
                     for s in scene.spheres() {
                         isect = ray.intersect(s, isect);
                     }

--- a/examples/aobench/src/vector_parallel.rs
+++ b/examples/aobench/src/vector_parallel.rs
@@ -16,7 +16,7 @@ pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
         let image = unsafe {
             ::std::slice::from_raw_parts_mut(image_ptr as *mut f32, image_len)
         };
-        let mut scene = S::new();
+        let mut scene = S::default();
         for x in 0..w {
             let offset = 3 * (y * w + x);
             for u in 0..ns {
@@ -33,11 +33,11 @@ pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
                     let dir = dir.normalized();
 
                     let ray = Ray {
-                        origin: V3D::new(),
+                        origin: V3D::default(),
                         dir,
                     };
 
-                    let mut isect = Isect::new();
+                    let mut isect = Isect::default();
                     for s in scene.spheres() {
                         isect = ray.intersect(s, isect);
                     }

--- a/examples/fannkuch_redux/src/lib.rs
+++ b/examples/fannkuch_redux/src/lib.rs
@@ -1,6 +1,16 @@
 //! Fannkuch redux
+#![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types)]
-
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        similar_names,
+        many_single_char_names,
+        cast_possible_truncation,
+        cast_sign_loss,
+        cast_possible_wrap
+    )
+)]
 extern crate packed_simd;
 
 pub mod scalar;

--- a/examples/fannkuch_redux/src/main.rs
+++ b/examples/fannkuch_redux/src/main.rs
@@ -1,9 +1,11 @@
+#![deny(warnings)]
+
 extern crate fannkuch_redux_lib;
 use fannkuch_redux_lib::*;
 
 fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let (checksum, maxflips) = fannkuch_redux(n, alg);
-    write!(o, "{}\nPfannkuchen({}) = {}\n", checksum, n, maxflips).unwrap();
+    writeln!(o, "{}\nPfannkuchen({}) = {}", checksum, n, maxflips).unwrap();
 }
 
 fn main() {

--- a/examples/fannkuch_redux/src/scalar.rs
+++ b/examples/fannkuch_redux/src/scalar.rs
@@ -38,22 +38,22 @@ struct Perm {
 }
 
 impl Perm {
-    fn new(n: u32) -> Perm {
+    fn new(n: u32) -> Self {
         let mut fact = [1; 16];
         for i in 1..n as usize + 1 {
             fact[i] = fact[i - 1] * i as u32;
         }
-        Perm {
+        Self {
             cnt: [0; 16],
-            fact: fact,
-            n: n,
+            fact,
+            n,
             permcount: 0,
             perm: P { p: [0; 16] },
         }
     }
 
     fn get(&mut self, mut idx: i32) -> P {
-        let mut pp = [0u8; 16];
+        let mut pp = [0_u8; 16];
         self.permcount = idx as u32;
         for (i, place) in self.perm.p.iter_mut().enumerate() {
             *place = i as i32 + 1;
@@ -71,11 +71,11 @@ impl Perm {
 
             let d = d as usize;
             for j in 0..i + 1 {
-                self.perm.p[j] = if j + d <= i {
+                self.perm.p[j] = i32::from(if j + d <= i {
                     pp[j + d]
                 } else {
                     pp[j + d - i - 1]
-                } as i32;
+                });
             }
         }
 
@@ -141,7 +141,7 @@ pub fn fannkuch_redux(n: usize) -> (i32, i32) {
 
     let mut checksum = 0;
     let mut maxflips = 0;
-    for fut in futures.into_iter() {
+    for fut in futures {
         let (cs, mf) = fut.join().unwrap();
         checksum += cs;
         maxflips = cmp::max(maxflips, mf);

--- a/examples/mandelbrot/src/lib.rs
+++ b/examples/mandelbrot/src/lib.rs
@@ -2,6 +2,16 @@
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/mandelbrot.html#mandelbrot
 
+#![deny(warnings)]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        cast_precision_loss,
+        cast_sign_loss,
+        cast_possible_truncation
+    )
+)]
+
 extern crate packed_simd;
 use std::io;
 
@@ -37,7 +47,7 @@ impl Mandelbrot {
                 vec![0_u8; width / 8]
             }
         };
-        Mandelbrot {
+        Self {
             width,
             height,
             left: -1.5,

--- a/examples/mandelbrot/src/output.rs
+++ b/examples/mandelbrot/src/output.rs
@@ -7,14 +7,13 @@ pub enum Format {
     PBM,
     PPM,
 }
-use self::Format::*;
 
 pub type FormatFn = fn(&mut [u8], usize, u32) -> ();
 
-/// Portable PixMap format
+/// Portable pixmap format
 pub mod ppm {
     use super::*;
-    const COLOURS: &'static [(f32, f32, f32)] = &[
+    const COLOURS: &[(f32, f32, f32)] = &[
         (0.0, 7.0, 100.0),
         (32.0, 107.0, 203.0),
         (237.0, 255.0, 255.0),
@@ -24,7 +23,7 @@ pub mod ppm {
     const SCALE: f32 = 12.0;
 
     pub fn write_header<O: io::Write>(o: &mut O, width: usize, height: usize) {
-        write!(o, "P6\n{} {} 255\n", width, height).unwrap();
+        writeln!(o, "P6\n{} {} 255", width, height).unwrap();
     }
 
     pub fn output(line: &mut [u8], index: usize, val: u32) {
@@ -58,20 +57,20 @@ pub mod ppm {
 pub mod pbm {
     use super::*;
     pub fn write_header<O: io::Write>(o: &mut O, width: usize, height: usize) {
-        write!(o, "P4\n{} {}\n", width, height).unwrap();
+        writeln!(o, "P4\n{} {}", width, height).unwrap();
     }
 
     pub fn output(out: &mut [u8], index: usize, val: u32) {
-        let byte_index = index / 8;
-        let bit_index = index % 8;
-        debug_assert_eq!(byte_index * 8 + bit_index, index);
-
         fn set_bit(byte: u8, index: usize) -> u8 {
             byte | (1 << index as u8)
         }
         fn clear_bit(byte: u8, index: usize) -> u8 {
             byte & !(1 << index as u8)
         }
+
+        let byte_index = index / 8;
+        let bit_index = index % 8;
+        debug_assert_eq!(byte_index * 8 + bit_index, index);
 
         let mut byte = out[byte_index];
         if val == LIMIT {
@@ -90,14 +89,14 @@ pub fn write_header<O: io::Write>(
     format: Format,
 ) {
     match format {
-        PPM => ppm::write_header(o, width, height),
-        PBM => pbm::write_header(o, width, height),
+        Format::PPM => ppm::write_header(o, width, height),
+        Format::PBM => pbm::write_header(o, width, height),
     }
 }
 
 pub fn get_format_fn(format: Format) -> FormatFn {
     match format {
-        PPM => ppm::output,
-        PBM => pbm::output,
+        Format::PPM => ppm::output,
+        Format::PBM => pbm::output,
     }
 }

--- a/examples/mandelbrot/src/scalar.rs
+++ b/examples/mandelbrot/src/scalar.rs
@@ -32,6 +32,6 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
             let val = scalar::mandelbrot(x, y, limit);
             out_fn(&mut m.line, j, val);
         }
-        o.write(&m.line).unwrap();
+        o.write_all(&m.line).unwrap();
     }
 }

--- a/examples/mandelbrot/src/simd.rs
+++ b/examples/mandelbrot/src/simd.rs
@@ -8,7 +8,7 @@ pub fn mandelbrot(c_x: f64x4, c_y: f64x4, max_iter: u32) -> u32x4 {
     let mut y = c_y;
 
     let mut count = u64x4::splat(0);
-    let max_iter = u64x4::splat(max_iter as u64);
+    let max_iter = u64x4::splat(u64::from(max_iter));
 
     loop {
         let mask = count.ge(max_iter);
@@ -65,6 +65,6 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
                 out_fn(&mut m.line, j + k, ret.extract(k));
             }
         }
-        o.write(&m.line).unwrap();
+        o.write_all(&m.line).unwrap();
     }
 }

--- a/examples/matrix_inverse/src/scalar.rs
+++ b/examples/matrix_inverse/src/scalar.rs
@@ -136,9 +136,9 @@ pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
 
     let det_inv = 1. / det;
 
-    for i in 0..4 {
-        for j in 0..4 {
-            inv[i][j] *= det_inv;
+    for row in &mut inv {
+        for elem in row.iter_mut() {
+            *elem *= det_inv;
         }
     }
 

--- a/examples/nbody/src/lib.rs
+++ b/examples/nbody/src/lib.rs
@@ -2,7 +2,10 @@
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody
 #![deny(warnings)]
-
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(similar_names, excessive_precision)
+)]
 extern crate packed_simd;
 
 pub mod scalar;

--- a/examples/nbody/src/main.rs
+++ b/examples/nbody/src/main.rs
@@ -1,14 +1,14 @@
 //! The N-body benchmark from the [benchmarks game][bg].
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody
-
+#![deny(warnings)]
 extern crate nbody_lib;
 
 fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let (energy_before, energy_after) = nbody_lib::run(n, alg);
 
-    write!(o, "{:.9}\n", energy_before);
-    write!(o, "{:.9}\n", energy_after);
+    writeln!(o, "{:.9}", energy_before);
+    writeln!(o, "{:.9}", energy_after);
 }
 
 fn main() {

--- a/examples/nbody/src/scalar.rs
+++ b/examples/nbody/src/scalar.rs
@@ -15,6 +15,7 @@ struct Body {
 }
 
 const N_BODIES: usize = 5;
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 const BODIES: [Body; N_BODIES] = [
     // Sun
     Body {
@@ -82,32 +83,32 @@ const BODIES: [Body; N_BODIES] = [
 
 fn advance(bodies: &mut [Body; N_BODIES], dt: f64) {
     let mut b_slice: &mut [_] = bodies;
-    loop {
-        let bi = match shift_mut_ref(&mut b_slice) {
-            Some(bi) => bi,
-            None => break,
-        };
+    while let Some(bi) = shift_mut_ref(&mut b_slice) {
         for bj in b_slice.iter_mut() {
             let mut dx = [0.; 3];
-            for i in 0..3 {
-                dx[i] = bi.x[i] - bj.x[i];
+            for (dx, (x_i, x_j)) in
+                dx.iter_mut().zip(bi.x.iter().zip(bj.x.iter()))
+            {
+                *dx = x_i - x_j;
             }
 
             let mut d2: f64 = 0.;
-            for i in 0..3 {
-                d2 += dx[i] * dx[i];
+            for dx in &dx {
+                d2 += dx * dx;
             }
             let mag = dt / (d2 * d2.sqrt());
 
             let massi_mag = bi.mass * mag;
             let massj_mag = bj.mass * mag;
-            for i in 0..3 {
-                bj.v[i] += dx[i] * massi_mag;
-                bi.v[i] -= dx[i] * massj_mag;
+            for (v_j, (v_i, dx)) in
+                bj.v.iter_mut().zip(bi.v.iter_mut().zip(dx.iter()))
+            {
+                *v_j += dx * massi_mag;
+                *v_i -= dx * massj_mag;
             }
         }
-        for i in 0..3 {
-            bi.x[i] += dt * bi.v[i];
+        for (x, v) in bi.x.iter_mut().zip(bi.v.iter()) {
+            *x += dt * v;
         }
     }
 }
@@ -115,20 +116,16 @@ fn advance(bodies: &mut [Body; N_BODIES], dt: f64) {
 fn energy(bodies: &[Body; N_BODIES]) -> f64 {
     let mut e = 0.0;
     let mut bodies = bodies.iter();
-    loop {
-        let bi = match bodies.next() {
-            Some(bi) => bi,
-            None => break,
-        };
+    while let Some(bi) = bodies.next() {
         let mut e_l = 0.;
-        for i in 0..3 {
-            e_l += bi.v[i] * bi.v[i];
+        for v in &bi.v {
+            e_l += v * v;
         }
         e += e_l * bi.mass / 2.0;
         for bj in bodies.clone() {
             let mut dist = 0.;
-            for i in 0..3 {
-                let dx = bi.x[i] - bj.x[i];
+            for (xi, xj) in bi.x.iter().zip(bj.x.iter()) {
+                let dx = xi - xj;
                 dist += dx * dx;
             }
             e -= bi.mass * bj.mass / dist.sqrt();
@@ -140,20 +137,21 @@ fn energy(bodies: &[Body; N_BODIES]) -> f64 {
 fn offset_momentum(bodies: &mut [Body; N_BODIES]) {
     let mut p = [0.; 3];
     for bi in bodies.iter() {
-        for i in 0..3 {
-            p[i] += bi.v[i] * bi.mass;
+        for (p, v) in p.iter_mut().zip(bi.v.iter()) {
+            *p += v * bi.mass;
         }
     }
     let sun = &mut bodies[0];
-    for i in 0..3 {
-        sun.v[i] = -p[i] / SOLAR_MASS;
+    for (v, p) in sun.v.iter_mut().zip(p.iter()) {
+        *v = -p / SOLAR_MASS;
     }
 }
 
 /// Pop a mutable reference off the head of a slice, mutating the slice to no
 /// longer contain the mutable reference.
+#[cfg_attr(feature = "cargo-clippy", allow(mut_mut))]
 fn shift_mut_ref<'a, T>(r: &mut &'a mut [T]) -> Option<&'a mut T> {
-    if r.len() == 0 {
+    if r.is_empty() {
         return None;
     }
     let tmp = ::std::mem::replace(r, &mut []);

--- a/examples/nbody/src/simd.rs
+++ b/examples/nbody/src/simd.rs
@@ -12,6 +12,7 @@ pub struct Body {
     pub mass: f64,
 }
 const N_BODIES: usize = 5;
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 const BODIES: [Body; N_BODIES] = [
     // sun:
     Body {

--- a/examples/spectral_norm/src/lib.rs
+++ b/examples/spectral_norm/src/lib.rs
@@ -1,5 +1,7 @@
 //! Spectral Norm
+#![deny(warnings)]
 #![allow(non_snake_case, non_camel_case_types)]
+#![cfg_attr(feature = "cargo-clippy", allow(cast_precision_loss))]
 
 extern crate packed_simd;
 

--- a/examples/spectral_norm/src/main.rs
+++ b/examples/spectral_norm/src/main.rs
@@ -1,9 +1,11 @@
+#![deny(warnings)]
+
 extern crate spectral_norm_lib;
 use spectral_norm_lib::*;
 
 fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let answer = spectral_norm(n, alg);
-    write!(o, "{:.9}\n", answer).unwrap();
+    writeln!(o, "{:.9}", answer).unwrap();
 }
 
 fn main() {

--- a/examples/spectral_norm/src/scalar.rs
+++ b/examples/spectral_norm/src/scalar.rs
@@ -38,7 +38,7 @@ fn mult_AtAv(v: &[f64], out: &mut [f64], tmp: &mut [f64]) {
 }
 
 fn mult_Av(v: &[f64], out: &mut [f64]) {
-    mult(v, out, 0, |i, j| A(i, j));
+    mult(v, out, 0, A);
 }
 
 fn mult_Atv(v: &[f64], out: &mut [f64]) {

--- a/examples/spectral_norm/src/simd.rs
+++ b/examples/spectral_norm/src/simd.rs
@@ -7,7 +7,7 @@ fn mult_Av(v: &[f64], out: &mut [f64]) {
     assert!(v.len() == out.len());
     assert!(v.len() % 2 == 0);
 
-    for i in 0..v.len() {
+    for (i, out) in out.iter_mut().enumerate() {
         let mut sum = f64x2::splat(0.0);
 
         let mut j = 0;
@@ -17,7 +17,7 @@ fn mult_Av(v: &[f64], out: &mut [f64]) {
             sum += b / a;
             j += 2
         }
-        out[i] = sum.sum();
+        *out = sum.sum();
     }
 }
 
@@ -25,7 +25,7 @@ fn mult_Atv(v: &[f64], out: &mut [f64]) {
     assert!(v.len() == out.len());
     assert!(v.len() % 2 == 0);
 
-    for i in 0..v.len() {
+    for (i, out) in out.iter_mut().enumerate() {
         let mut sum = f64x2::splat(0.0);
 
         let mut j = 0;
@@ -35,7 +35,7 @@ fn mult_Atv(v: &[f64], out: &mut [f64]) {
             sum += b / a;
             j += 2
         }
-        out[i] = sum.sum();
+        *out = sum.sum();
     }
 }
 


### PR DESCRIPTION
This PR: 

* uses the `name:` key to name each travis build bot. 
* requires `rustup target add $TARGET` to succeed (and bails early if it doesn't) - the targets that already come with the appropriate toolchain installed use `install: true` to skip this step
* uses `travis_retry` to reduce the number of spurious failures when `rustup` times out
* handles each set of target features in a different build bot to avoid spurious failures when the builds were reaching the hard 50 min maximum