### PR TITLE
rename shuffle_bytes to permute_dyn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,6 @@ matrix:
     #- env: TARGET=x86_64-unknown-netbsd NORUN=1
     #- env: TARGET=x86_64-sun-solaris NORUN=1
 
-    # Also failing on libc:
-    - env: TARGET=sparc64-unknown-linux-gnu
-
     # FIXME: TBD
     - env: TARGET=arm-linux-androideabi
     - env: TARGET=arm-linux-androideabi RUSTFLAGS="-C target-feature=+v7,+neon"

--- a/ci/run_examples.sh
+++ b/ci/run_examples.sh
@@ -6,6 +6,12 @@ if [[ ${TARGET} == "armv7-apple-ios" ]]; then
     exit 0
 fi
 
+# FIXME: travis exceeds 50 minutes on these targets
+# Skipping the examples is an attempt at preventing travis from timing-out
+if [[ ${TARGET} == "arm-linux-androidabi" ]] || [[ ${TARGET} == "aarch64-linux-androidabi" ]]; then
+    exit 0
+fi
+
 cp -r examples/aobench target/aobench
 cargo_test --manifest-path=target/aobench/Cargo.toml --release --no-default-features
 cargo_test --manifest-path=target/aobench/Cargo.toml --release --features=256bit

--- a/examples/aobench/src/main.rs
+++ b/examples/aobench/src/main.rs
@@ -4,7 +4,6 @@
 //! Fujita.
 #![deny(warnings)]
 
-#[macro_use]
 extern crate structopt;
 extern crate aobench_lib;
 extern crate time;

--- a/examples/fannkuch_redux/src/simd.rs
+++ b/examples/fannkuch_redux/src/simd.rs
@@ -57,7 +57,7 @@ impl State {
     }
     fn rotate(&mut self, n: usize) {
         self.load_s()
-            .shuffle_bytes(self.rotate_masks[n])
+            .permute_dyn(self.rotate_masks[n])
             .write_to_slice_unaligned(&mut self.s)
     }
 
@@ -124,9 +124,9 @@ impl State {
 
                 while toterm1 != 0 && toterm2 != 0 {
                     perm1 =
-                        perm1.shuffle_bytes(self.flip_masks[toterm1 as usize]);
+                        perm1.permute_dyn(self.flip_masks[toterm1 as usize]);
                     perm2 =
-                        perm2.shuffle_bytes(self.flip_masks[toterm2 as usize]);
+                        perm2.permute_dyn(self.flip_masks[toterm2 as usize]);
                     toterm1 = perm1.extract(0);
                     toterm2 = perm2.extract(0);
 
@@ -135,13 +135,13 @@ impl State {
                 }
                 while toterm1 != 0 {
                     perm1 =
-                        perm1.shuffle_bytes(self.flip_masks[toterm1 as usize]);
+                        perm1.permute_dyn(self.flip_masks[toterm1 as usize]);
                     toterm1 = perm1.extract(0);
                     f1 += 1;
                 }
                 while toterm2 != 0 {
                     perm2 =
-                        perm2.shuffle_bytes(self.flip_masks[toterm2 as usize]);
+                        perm2.permute_dyn(self.flip_masks[toterm2 as usize]);
                     toterm2 = perm2.extract(0);
                     f2 += 1;
                 }
@@ -163,8 +163,7 @@ impl State {
                 let mut f = 0;
                 let mut toterm = pk.start;
                 while toterm != 0 {
-                    perm =
-                        perm.shuffle_bytes(self.flip_masks[toterm as usize]);
+                    perm = perm.permute_dyn(self.flip_masks[toterm as usize]);
                     toterm = perm.extract(0);
                     f += 1;
                 }

--- a/examples/matrix_inverse/src/lib.rs
+++ b/examples/matrix_inverse/src/lib.rs
@@ -8,7 +8,6 @@ pub mod scalar;
 pub mod simd;
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-#[repr(align(32))]
 pub struct Matrix4x4([[f32; 4]; 4]);
 
 #[cfg(test)]

--- a/examples/matrix_inverse/src/simd.rs
+++ b/examples/matrix_inverse/src/simd.rs
@@ -5,10 +5,10 @@ use packed_simd::f32x4;
 
 pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
     let m = m.0;
-    let m_0 = f32x4::from_slice_aligned(&m[0]);
-    let m_1 = f32x4::from_slice_aligned(&m[1]);
-    let m_2 = f32x4::from_slice_aligned(&m[2]);
-    let m_3 = f32x4::from_slice_aligned(&m[3]);
+    let m_0 = f32x4::from_slice_unaligned(&m[0]);
+    let m_1 = f32x4::from_slice_unaligned(&m[1]);
+    let m_2 = f32x4::from_slice_unaligned(&m[2]);
+    let m_3 = f32x4::from_slice_unaligned(&m[3]);
 
     let tmp1: f32x4 = shuffle!(m_0, m_1, [0, 1, 4, 5]);
     let row1: f32x4 = shuffle!(m_2, m_3, [0, 1, 4, 5]);
@@ -92,10 +92,10 @@ pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
 
     let mut m = m;
 
-    res0.write_to_slice_aligned(&mut m[0]);
-    res1.write_to_slice_aligned(&mut m[1]);
-    res2.write_to_slice_aligned(&mut m[2]);
-    res3.write_to_slice_aligned(&mut m[3]);
+    res0.write_to_slice_unaligned(&mut m[0]);
+    res1.write_to_slice_unaligned(&mut m[1]);
+    res2.write_to_slice_unaligned(&mut m[2]);
+    res3.write_to_slice_unaligned(&mut m[3]);
 
     Some(Matrix4x4(m))
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,7 +28,7 @@ mod select;
 #[macro_use]
 mod shuffle;
 #[macro_use]
-mod shuffle_bytes;
+mod permute_dyn;
 #[macro_use]
 mod slice;
 #[macro_use]
@@ -135,7 +135,7 @@ macro_rules! impl_u {
         impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
-        impl_shuffle_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        impl_permute_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_cmp_partial_eq!(
             [$elem_ty; $elem_n]: $tuple_id | $test_tt | (1, 0)
         );

--- a/src/api/permute_dyn.rs
+++ b/src/api/permute_dyn.rs
@@ -1,22 +1,22 @@
-//! Shuffle bytes with run-time indices
+//! Permute elements of a vector with a dynamic vector of indices.
 
-macro_rules! impl_shuffle_bytes {
+macro_rules! impl_permute_dyn {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
         impl $id {
-            /// Shuffles the bytes of the vector according to `indices`.
+            /// Permute vector lanes according to `indices`.
             #[inline]
-            pub fn shuffle_bytes(self, indices: Self) -> Self {
-                codegen::shuffle_bytes::ShuffleBytes::shuffle_bytes(self, indices)
+            pub fn permute_dyn(self, indices: Self) -> Self {
+                codegen::permute_dyn::PermuteDyn::permute_dyn(self, indices)
             }
         }
 
         test_if! {
             $test_tt:
             interpolate_idents! {
-                mod [$id _shuffle_bytes] {
+                mod [$id _permute_dyn] {
                     use super::*;
                     #[test]
-                    fn shuffle_bytes() {
+                    fn permute_dyn() {
                         let increasing = {
                             let mut v = $id::splat(0);
                             for i in 0..$id::lanes() {
@@ -32,20 +32,20 @@ macro_rules! impl_shuffle_bytes {
                             v
                         };
 
-                        assert_eq!(increasing.shuffle_bytes(increasing), increasing, "(i,i)=>i");
-                        assert_eq!(decreasing.shuffle_bytes(increasing), decreasing, "(d,i)=>d");
-                        assert_eq!(increasing.shuffle_bytes(decreasing), decreasing, "(i,d)=>d");
-                        assert_eq!(decreasing.shuffle_bytes(decreasing), increasing, "(d,d)=>i");
+                        assert_eq!(increasing.permute_dyn(increasing), increasing, "(i,i)=>i");
+                        assert_eq!(decreasing.permute_dyn(increasing), decreasing, "(d,i)=>d");
+                        assert_eq!(increasing.permute_dyn(decreasing), decreasing, "(i,d)=>d");
+                        assert_eq!(decreasing.permute_dyn(decreasing), increasing, "(d,d)=>i");
 
                         for i in 0..$id::lanes() {
-                            assert_eq!(increasing.shuffle_bytes($id::splat(i as $elem_ty)),
+                            assert_eq!(increasing.permute_dyn($id::splat(i as $elem_ty)),
                                        $id::splat(increasing.extract(i)));
-                            assert_eq!(decreasing.shuffle_bytes($id::splat(i as $elem_ty)),
+                            assert_eq!(decreasing.permute_dyn($id::splat(i as $elem_ty)),
                                        $id::splat(decreasing.extract(i)));
 
-                            assert_eq!($id::splat(i as $elem_ty).shuffle_bytes(increasing),
+                            assert_eq!($id::splat(i as $elem_ty).permute_dyn(increasing),
                                        $id::splat(i as $elem_ty));
-                            assert_eq!($id::splat(i as $elem_ty).shuffle_bytes(decreasing),
+                            assert_eq!($id::splat(i as $elem_ty).permute_dyn(decreasing),
                                        $id::splat(i as $elem_ty));
                         }
 

--- a/src/api/slice/from_slice.rs
+++ b/src/api/slice/from_slice.rs
@@ -14,9 +14,9 @@ macro_rules! impl_slice_from_slice {
                 unsafe {
                     assert!(slice.len() >= $elem_count);
                     let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
-                    assert!(
-                        target_ptr.align_offset(mem::align_of::<Self>())
-                            == 0
+                    assert_eq!(
+                        target_ptr.align_offset(mem::align_of::<Self>()),
+                        0
                     );
                     Self::from_slice_aligned_unchecked(slice)
                 }

--- a/src/api/slice/write_to_slice.rs
+++ b/src/api/slice/write_to_slice.rs
@@ -15,9 +15,9 @@ macro_rules! impl_slice_write_to_slice {
                     assert!(slice.len() >= $elem_count);
                     let target_ptr =
                         slice.get_unchecked_mut(0) as *mut $elem_ty;
-                    assert!(
-                        target_ptr.align_offset(mem::align_of::<Self>())
-                            == 0
+                    assert_eq!(
+                        target_ptr.align_offset(mem::align_of::<Self>()),
+                        0
                     );
                     self.write_to_slice_aligned_unchecked(slice);
                 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2,9 +2,9 @@
 
 crate mod llvm;
 crate mod math;
+crate mod permute_dyn;
 crate mod reductions;
 crate mod shuffle;
-crate mod shuffle_bytes;
 crate mod swap_bytes;
 
 macro_rules! impl_simd_array {


### PR DESCRIPTION
The `shuffle_bytes` vector wasn't actually shuffling bytes, but performing a vector permute with dynamic indices. This PR renames it to `permute_dyn` to indicate that the indices are dynamic. This allows us to reserve `.permute()` for use with constant indices once Rust gains support for `const` function arguments. Until then users can use `shuffle!` to perform permutes.