### PR TITLE
Fix FANNKUCH example range check

### DIFF
--- a/examples/fannkuch_redux/src/main.rs
+++ b/examples/fannkuch_redux/src/main.rs
@@ -11,7 +11,7 @@ fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
 fn main() {
     let n: usize =
         std::env::args().nth(1).expect("need one arg").parse().unwrap();
-    assert!(n <= 3 && n <= 14, "n = {} is out-of-range [3, 14]", n);
+    assert!(3 <= n && n <= 14, "n = {} is out-of-range [3, 14]", n);
     let alg = if let Some(v) = std::env::args().nth(2) {
         v.parse().unwrap()
     } else {


### PR DESCRIPTION
I tried to run the `fannkuch_redux` example but it didn't work because the range check in the assert was inverted.