### PR TITLE
Add .gitignore for `stencil` example

### DIFF
--- a/examples/stencil/volta/.gitignore
+++ b/examples/stencil/volta/.gitignore
@@ -1,0 +1,3 @@
+# Files built by ISPC
+/objs/
+/stencil


### PR DESCRIPTION
The `ao` example already had one, this one was missing.