### PR TITLE
Add documentation for fused-multiply subtract

### DIFF
--- a/src/api/math/float/fma.rs
+++ b/src/api/math/float/fma.rs
@@ -4,6 +4,12 @@ macro_rules! impl_math_float_fma {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
         impl $id {
             /// Fused multiply add: `self * y + z`
+            ///
+            /// Most architectures which have support for FMA
+            /// also have an equivalent version of this function,
+            /// fused multiply subtract (`self * y - z`).
+            /// Simply negating the second parameter of this function
+            /// will make the compiler generate it.
             #[inline]
             pub fn fma(self, y: Self, z: Self) -> Self {
                 use crate::codegen::math::float::fma::Fma;


### PR DESCRIPTION
Negating the second argument of `fma` will make LLVM generate `vfmsub`. LLVM has [unit tests](https://github.com/llvm-mirror/llvm/blob/master/test/CodeGen/X86/avx2-fma-fneg-combine.ll) to guarantee this behavior. This pull request documents this fact.

Closes #111.