### PR TITLE
Performance improvements for benchmarks

### DIFF
--- a/examples/aobench/src/geometry/vec.rs
+++ b/examples/aobench/src/geometry/vec.rs
@@ -60,6 +60,15 @@ impl V3D {
         basis[1] = basis[2].cross(basis[0]).normalized();
         basis
     }
+    // Fuzzy float comparison between vectors
+    #[inline(always)]
+    #[must_use]
+    pub fn almost_eq(&self, rhs: &Self) -> bool {
+        const EPSILON: f32 = 1E-3;
+        (self.x - rhs.x).abs() < EPSILON &&
+        (self.y - rhs.y).abs() < EPSILON &&
+        (self.z - rhs.z).abs() < EPSILON
+    }
 }
 
 impl Add for V3D {

--- a/examples/aobench/src/geometry/vec.rs
+++ b/examples/aobench/src/geometry/vec.rs
@@ -36,7 +36,9 @@ impl V3D {
     #[inline(always)]
     #[must_use]
     pub fn normalized(self) -> Self {
-        self * (1. / self.dot(self).sqrt())
+        let len2 = self.dot(self);
+        let invlen = len2.sqrt().recip();
+        invlen * self
     }
     #[inline(always)]
     #[must_use]

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -60,7 +60,7 @@ impl Intersect<Plane> for RayxN {
                 let old_isect_i = old_isect.get(i);
                 let ray_i = self.get(i);
                 let isect_i = ray_i.intersect(plane, old_isect_i);
-                assert_eq!(isect_i, isect.get(i), "\n\nplane: {:?}\n\nold_isect: {:?}\n\nrays: {:?}\n\ni: {:?}\nold_isect_i: {:?}\nray_i: {:?}\nisect_i: {:?}\n\n", plane, old_isect, self, i, old_isect_i, ray_i, isect_i);
+                assert!(isect_i.almost_eq(&isect.get(i)), "{:?} !~= {:?}\n\nplane: {:?}\n\nold_isect: {:?}\n\nrays: {:?}\n\ni: {:?}\nold_isect_i: {:?}\nray_i: {:?}\n\n", isect_i, isect.get(i), plane, old_isect, self, i, old_isect_i, ray_i);
             }
             true
         });

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -39,8 +39,9 @@ impl Intersect<Sphere> for RayxN {
         let rs = ray.origin - sphere.center;
 
         let b = rs.dot(ray.dir);
-        let c = rs.dot(rs) - sphere.radius * sphere.radius;
-        let d = b * b - c;
+        let radius = f32xN::splat(sphere.radius);
+        let c = radius.mul_adde(-radius, rs.dot(rs));
+        let d = b.mul_adde(b, -c);
 
         let old_isect = isect;
 

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -66,7 +66,7 @@ impl Intersect<Sphere> for RayxN {
                 let old_isect_i = old_isect.get(i);
                 let ray_i = self.get(i);
                 let isect_i = ray_i.intersect(sphere, old_isect_i);
-                assert_eq!(isect_i, isect.get(i), "\n\nsphere: {:?}\n\nold_isect: {:?}\n\nrays: {:?}\n\ni: {:?}\nold_isect_i: {:?}\nray_i: {:?}\nisect_i: {:?}\n\n", sphere, old_isect, self, i, old_isect_i, ray_i, isect_i);
+                assert!(isect_i.almost_eq(&isect.get(i)), "{:?} !~= {:?}\n\nsphere: {:?}\n\nold_isect: {:?}\n\nrays: {:?}\n\ni: {:?}\nold_isect_i: {:?}\nray_i: {:?}\n\n", isect_i, isect.get(i), sphere, old_isect, self, i, old_isect_i, ray_i);
             }
             true
         });

--- a/examples/aobench/src/intersection/single.rs
+++ b/examples/aobench/src/intersection/single.rs
@@ -3,7 +3,7 @@
 use geometry::V3D;
 
 /// Intersection result
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct Isect {
     pub t: f32,
     pub p: V3D,
@@ -20,5 +20,17 @@ impl Default for Isect {
             p: V3D::default(),
             n: V3D::default(),
         }
+    }
+}
+
+impl Isect {
+    #[inline(always)]
+    #[must_use]
+    pub fn almost_eq(&self, rhs: &Isect) -> bool {
+        const EPSILON: f32 = 1E-3;
+        (self.t - rhs.t).abs() < EPSILON &&
+        self.p.almost_eq(&rhs.p) &&
+        self.n.almost_eq(&rhs.n) &&
+        self.hit == rhs.hit
     }
 }

--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -91,6 +91,7 @@ pub mod vector {
             RngT(z0, z1, z2, z3)
         }
 
+        #[inline]
         pub fn gen_u32(&mut self) -> u32xN {
             let mut b = ((self.0 << 6) ^ self.0) >> 13;
             self.0 = ((self.0 & u32xN::splat(4_294_967_294)) << 18) ^ b;
@@ -103,6 +104,7 @@ pub mod vector {
             self.0 ^ self.1 ^ self.2 ^ self.3
         }
 
+        #[inline]
         pub fn gen(&mut self) -> f32xN {
             let mut v = self.gen_u32();
             v &= u32xN::splat((1_u32 << 23) - 1);
@@ -119,6 +121,7 @@ pub mod vector {
     }
 
     impl RngH {
+        #[inline]
         pub fn gen(&mut self) -> f32xN {
             unsafe { (*self.rng.get()).gen() }
         }

--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -91,7 +91,7 @@ pub mod vector {
             RngT(z0, z1, z2, z3)
         }
 
-        #[inline]
+        #[inline(always)]
         pub fn gen_u32(&mut self) -> u32xN {
             let mut b = ((self.0 << 6) ^ self.0) >> 13;
             self.0 = ((self.0 & u32xN::splat(4_294_967_294)) << 18) ^ b;
@@ -104,7 +104,7 @@ pub mod vector {
             self.0 ^ self.1 ^ self.2 ^ self.3
         }
 
-        #[inline]
+        #[inline(always)]
         pub fn gen(&mut self) -> f32xN {
             let mut v = self.gen_u32();
             v &= u32xN::splat((1_u32 << 23) - 1);
@@ -121,7 +121,7 @@ pub mod vector {
     }
 
     impl RngH {
-        #[inline]
+        #[inline(always)]
         pub fn gen(&mut self) -> f32xN {
             unsafe { (*self.rng.get()).gen() }
         }

--- a/examples/aobench/src/scene/random.rs
+++ b/examples/aobench/src/scene/random.rs
@@ -55,15 +55,19 @@ impl Default for Random {
 
 impl Scene for Random {
     const NAO_SAMPLES: usize = 8;
+    #[inline(always)]
     fn rand(&mut self) -> f32 {
         ::random::scalar::thread_rng().gen()
     }
+    #[inline(always)]
     fn plane(&self) -> &Plane {
         &self.plane
     }
+    #[inline(always)]
     fn spheres(&self) -> &[Sphere] {
         &self.spheres
     }
+    #[inline(always)]
     fn rand_f32xN(&mut self) -> (f32xN, f32xN) {
         let mut rng = ::random::vector::thread_rng();
         (rng.gen(), rng.gen())

--- a/examples/aobench/src/tiled.rs
+++ b/examples/aobench/src/tiled.rs
@@ -86,7 +86,13 @@ cfg_if! {
             ao_impl(scene, nsubsamples, img);
         }
 
-        #[target_feature(enable = "avx2")]
+        #[target_feature(enable = "avx,fma")]
+        unsafe fn ao_avx_fma<S: Scene>(scene: &mut S, nsubsamples: usize,
+                                   img: &mut ::Image) {
+            ao_impl(scene, nsubsamples, img);
+        }
+
+        #[target_feature(enable = "avx2,fma")]
         unsafe fn ao_avx2<S: Scene>(scene: &mut S, nsubsamples: usize,
                                     img: &mut ::Image) {
             ao_impl(scene, nsubsamples, img);
@@ -95,10 +101,14 @@ cfg_if! {
         pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize,
                             img: &mut ::Image) {
             unsafe {
-                if is_x86_feature_detected!("avx2") {
+                if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
                     ao_avx2(scene, nsubsamples, img);
                 } else if is_x86_feature_detected!("avx") {
-                    ao_avx(scene, nsubsamples, img);
+                    if is_x86_feature_detected!("fma") {
+                        ao_avx_fma(scene, nsubsamples, img);
+                    } else {
+                        ao_avx(scene, nsubsamples, img);
+                    }
                 } else if is_x86_feature_detected!("sse4.2") {
                     ao_sse42(scene, nsubsamples, img);
                 } else {

--- a/examples/aobench/src/vector.rs
+++ b/examples/aobench/src/vector.rs
@@ -23,8 +23,8 @@ fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
                         (x as f32, y as f32, h as f32, w as f32);
 
                     let dir = V3D {
-                        x: (x + du - (w / 2.)) / (w / 2.) * w / h,
-                        y: -(y + dv - (h / 2.)) / (h / 2.),
+                        x: (x + du - (w * 0.5)) / (w * 0.5) * w / h,
+                        y: -(y + dv - (h * 0.5)) / (h * 0.5),
                         z: -1.,
                     };
                     let dir = dir.normalized();
@@ -72,7 +72,7 @@ cfg_if! {
             ao_impl(scene, nsubsamples, img);
         }
 
-        #[target_feature(enable = "avx2")]
+        #[target_feature(enable = "avx2,fma")]
         unsafe fn ao_avx2<S: Scene>(scene: &mut S, nsubsamples: usize,
                                     img: &mut ::Image) {
             ao_impl(scene, nsubsamples, img);
@@ -81,7 +81,7 @@ cfg_if! {
         pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize,
                             img: &mut ::Image) {
             unsafe {
-                if is_x86_feature_detected!("avx2") {
+                if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
                     ao_avx2(scene, nsubsamples, img);
                 } else if is_x86_feature_detected!("avx") {
                     ao_avx(scene, nsubsamples, img);

--- a/examples/aobench/src/vector.rs
+++ b/examples/aobench/src/vector.rs
@@ -72,6 +72,12 @@ cfg_if! {
             ao_impl(scene, nsubsamples, img);
         }
 
+        #[target_feature(enable = "avx,fma")]
+        unsafe fn ao_avx_fma<S: Scene>(scene: &mut S, nsubsamples: usize,
+                                   img: &mut ::Image) {
+            ao_impl(scene, nsubsamples, img);
+        }
+
         #[target_feature(enable = "avx2,fma")]
         unsafe fn ao_avx2<S: Scene>(scene: &mut S, nsubsamples: usize,
                                     img: &mut ::Image) {
@@ -84,7 +90,11 @@ cfg_if! {
                 if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
                     ao_avx2(scene, nsubsamples, img);
                 } else if is_x86_feature_detected!("avx") {
-                    ao_avx(scene, nsubsamples, img);
+                    if is_x86_feature_detected!("fma") {
+                        ao_avx_fma(scene, nsubsamples, img);
+                    } else {
+                        ao_avx(scene, nsubsamples, img);
+                    }
                 } else if is_x86_feature_detected!("sse4.2") {
                     ao_sse42(scene, nsubsamples, img);
                 } else {

--- a/examples/fannkuch_redux/src/simd.rs
+++ b/examples/fannkuch_redux/src/simd.rs
@@ -78,6 +78,9 @@ impl State {
         let mut i = 0;
         let mut c = [0_u8; 16];
         let mut perm_max = 0;
+        // Cache this locally outside the loop, since the compiler
+        // can't optimize accesses to it otherwise.
+        let mut odd = self.odd;
 
         while i < n {
             while i < n && perm_max < 60 {
@@ -90,17 +93,17 @@ impl State {
 
                 c[i] += 1;
                 i = 1;
-                self.odd = !self.odd;
+                odd = !odd;
                 if self.s[0] != 0 {
                     if self.s[self.s[0] as usize] == 0 {
                         if self.maxflips == 0 {
                             self.maxflips = 1
                         }
-                        self.checksum += if self.odd == 0 { 1 } else { -1 };
+                        self.checksum += if odd == 0 { 1 } else { -1 };
                     } else {
                         perms[perm_max].perm = self.load_s();
                         perms[perm_max].start = self.s[0];
-                        perms[perm_max].odd = self.odd;
+                        perms[perm_max].odd = odd;
                         perm_max += 1;
                     }
                 }

--- a/examples/stencil/src/lib.rs
+++ b/examples/stencil/src/lib.rs
@@ -133,22 +133,24 @@ fn assert_data_eq(a: &Data, b: &Data) {
             for x in 0..a.n.0 {
                 let idx = (x + y * a.n.1 + z * a.n.1 * a.n.0) as usize;
 
-                assert_eq!(
-                    a.vsq[idx], b.vsq[idx],
+                const EPSILON: f32 = 1E-4;
+
+                assert!(
+                    (a.vsq[idx] - b.vsq[idx]).abs() < EPSILON,
                     "vsq diff at idx = {} ({}, {}, {})",
-                    idx, x, y, z
+                    idx, x, y, z,
                 );
 
-                assert_eq!(
-                    a.a.0[idx], b.a.0[idx],
+                assert!(
+                    (a.a.0[idx] - b.a.0[idx]).abs() < EPSILON,
                     "a.0 diff at idx = {} ({}, {}, {})",
-                    idx, x, y, z
+                    idx, x, y, z,
                 );
 
-                assert_eq!(
-                    a.a.1[idx], b.a.1[idx],
+                assert!(
+                    (a.a.1[idx] - b.a.1[idx]).abs() < EPSILON,
                     "a.1 diff at idx = {} ({}, {}, {})",
-                    idx, x, y, z
+                    idx, x, y, z,
                 );
             }
         }

--- a/examples/stencil/src/lib.rs
+++ b/examples/stencil/src/lib.rs
@@ -83,15 +83,17 @@ impl Data {
         for z in 0..self.n.2 {
             for y in 0..self.n.1 {
                 for x in 0..self.n.0 {
-                    self.a.0[offset] = if x < self.n.0 / 2 {
-                        x as f32 / self.n.0 as f32
-                    } else {
-                        y as f32 / self.n.1 as f32
-                    };
-                    self.a.1[offset] = 0.;
-                    self.vsq[offset] = (x * y * z) as f32
-                        / (self.n.0 * self.n.1 * self.n.2) as f32;
-                    offset += 1;
+                    unsafe {
+                        *self.a.0.get_unchecked_mut(offset) = if x < self.n.0 / 2 {
+                            x as f32 / self.n.0 as f32
+                        } else {
+                            y as f32 / self.n.1 as f32
+                        };
+                        *self.a.1.get_unchecked_mut(offset) = 0.;
+                        *self.vsq.get_unchecked_mut(offset) = (x * y * z) as f32
+                            / (self.n.0 * self.n.1 * self.n.2) as f32;
+                        offset += 1;
+                    }
                 }
             }
         }

--- a/examples/stencil/src/scalar.rs
+++ b/examples/stencil/src/scalar.rs
@@ -63,7 +63,8 @@ pub fn scalar(
 #[cfg(all(test, feature = "ispc"))]
 mod tests {
     use super::scalar;
-    use {ispc_loops::serial, Data};
+    use ispc_loops::serial;
+    use {assert_data_eq, Data};
 
     #[test]
 
@@ -74,6 +75,6 @@ mod tests {
         let mut data_ispc = Data::default();
         data_ispc.exec(serial);
 
-        assert_eq!(data_scalar, data_ispc);
+        assert_data_eq(&data_scalar, &data_ispc);
     }
 }


### PR DESCRIPTION
This pull request contains improvements to the performance of the example crates in this repository.

## fannkuch_redux

- I noticed a small performance reduction because LLVM was emitting memory accesses to the `self.odd` field, insted of storing it in a register.
  Not sure why this happens, LLVM should know we borrow `self` mutably & have exclusive access to `self` and be able to cache its value locally.

- Overall, about 1.5% better performance.

## stencil

See issue #95 for the full discussion.

- Now we're using `mul_adde` (FMA) where possible.
- Improved performance of `Data::reinit` by using unsafe memory accesses. Not part of the benchmark, but it was slow and showing up a lot in the profiler.
- The parallel code is slower than the SIMD code now:
```
simd: 175 ms
simd+par: 279 ms
ispc: 176 ms
ispc+tasks: 373 ms
```
  I guess that's... good?

### Failing tests
- I've updated the testing code to use approximative float comparisons, with an error no larger than 10^-4.

## aobench

- Added `mul_adde` to most places, matching ISPC's assembly.
- Inlined some functions which weren't getting inlined before.
- Overall, when using the system math library (instead of comparing against ISPC's built-in one) Rust performance is better than with ISPC.