### PR TITLE
Fix building executable without PIE

### DIFF
--- a/examples/aobench/volta/common.mk
+++ b/examples/aobench/volta/common.mk
@@ -8,7 +8,7 @@ CXXFLAGS+=-Iobjs/ -O3 -march=native
 CC=clang
 CCFLAGS+=-Iobjs/ -O3 -march=native
 
-LIBS=-lm $(TASK_LIB) -lstdc++
+LIBS=$(TASK_LIB) -lstdc++ -no-pie
 ISPC=ispc
 ISPC_FLAGS+=-O3
 ISPC_HEADER=objs/$(ISPC_SRC:.ispc=_ispc.h)


### PR DESCRIPTION
Some Linux distros enable Position Independent Executables by default, which leads to ISPC being unable to link the binary. Since we're not really interested in better security for the benchmark, this pull request unconditionally disables PIE.

Also, I have removed `libm` from the link args, because ISPC never linked against it anyway (unless it was forced to with `--math-lib=system`).

Fixes #117.