### PR TITLE
Fix sleef conditional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ into_bits = []
 interpolate_idents = "0.2"
 arrayvec = { version = "^0.4", default-features = false }
 
-[target.'cfg(all(target_arch = "x86_64", target_feature = "sse2"))'.dependencies.sleef-sys]
+[target.'cfg(target_arch = "x86_64")'.dependencies.sleef-sys]
 version = "^0.1"
 optional = true
 


### PR DESCRIPTION
Considering x86_64 guarantees SSE2, I'm guessing this was meant to be an `any` instead of an `all`.