### PR TITLE
Improve Mandlebrot benchmark performance

### DIFF
--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 [dependencies]
 packed_simd = { path = "../.." }
 rayon = "^1.0"
+time = "^0.1"
 ispc = { version = "^0.3.6", optional = true }
 
 [build-dependencies]

--- a/examples/mandelbrot/readme.md
+++ b/examples/mandelbrot/readme.md
@@ -1,6 +1,6 @@
 # Mandelbrot
 
-This is the [`mandelbrot` benchmark from the benchmarksgame][bg]. 
+This is the [`mandelbrot` benchmark from the benchmarksgame][bg].
 
 ## Background
 
@@ -18,12 +18,14 @@ It takes four arguments in this order:
 * (optional) `output_format`: the output format to use - defaults to `PBM`
   * `0`: PBM: Portable BitMap format (black & white output)
   * `1`: PPM: Portable PixMap format (colored output)
-  
-`cargo run --release -- 400` outputs:
+
+The resulting image is piped to `stdout`.
+
+`cargo run --release -- 400 > output.ppm` outputs:
 
 ![run_400_png](https://user-images.githubusercontent.com/904614/43190942-72bdb834-8ffa-11e8-9dcf-a9a9632ae907.png)
 
-`cargo run --releae -- 400 400 1 1` outputs:
+`cargo run --release -- 400 400 1 1 > output.ppm` outputs:
 
 ![run_400_400_1_1_png](https://user-images.githubusercontent.com/904614/43190948-759969a4-8ffa-11e8-81a9-35e5baef3e86.png)
 

--- a/examples/mandelbrot/readme.md
+++ b/examples/mandelbrot/readme.md
@@ -68,10 +68,4 @@ On a 40 core Xeon Gold 6148 CPU @ 2.40GHz:
 
 `par_simd` algorithm is as fast as `ispc`.
 
-**Note**: While both algorithms produce the same output, they are however
-different. The `par_simd` implementation writes the formatted output in parallel
-inside from the main loop, while the ISPC algorithm computes the mandelbrot set
-first saving it to memory, and subsequently loads it from memory again to do the
-formatting.
-
 [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/mandelbrot.html#mandelbrot

--- a/examples/mandelbrot/src/ispc_.rs
+++ b/examples/mandelbrot/src/ispc_.rs
@@ -7,7 +7,7 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
     let out_fn = m.get_format_fn();
 
     let mut out = Vec::<i32>::with_capacity(m.height * m.width);
-    unsafe {
+    let dur = time::Duration::span(|| unsafe {
         mandelbrot::mandelbrot_ispc(
             m.left,
             m.bottom,
@@ -19,7 +19,8 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
             out.as_mut_ptr() as *mut i32,
         );
         out.set_len(m.height * m.width);
-    }
+    });
+    eprintln!("ispc: {} ms", dur.num_milliseconds());
 
     let mut line_buffer = m.line_buffer(1);
     for i in 0..m.height {

--- a/examples/mandelbrot/src/lib.rs
+++ b/examples/mandelbrot/src/lib.rs
@@ -15,6 +15,7 @@
 
 extern crate packed_simd;
 extern crate rayon;
+extern crate time;
 #[cfg(feature = "ispc")]
 #[macro_use]
 extern crate ispc;

--- a/examples/mandelbrot/src/lib.rs
+++ b/examples/mandelbrot/src/lib.rs
@@ -126,9 +126,14 @@ mod tests {
         }
 
         assert_eq!(v_expected.len(), 3 * w * h);
-        verify(w, h, &v_simd, &v_expected);
-        verify(w, h, &v_par_simd, &v_expected);
-        #[cfg(feature = "ispc")]
-        verify(w, h, &v_ispc, &v_expected);
+        #[cfg(not(target_feature = "fma"))]
+        {
+            verify(w, h, &v_simd, &v_expected);
+            verify(w, h, &v_par_simd, &v_expected);
+        }
+        if !is_x86_feature_detected!("fma") {
+            #[cfg(feature = "ispc")]
+            verify(w, h, &v_ispc, &v_expected);
+        }
     }
 }

--- a/examples/mandelbrot/src/lib.rs
+++ b/examples/mandelbrot/src/lib.rs
@@ -131,9 +131,15 @@ mod tests {
             verify(w, h, &v_simd, &v_expected);
             verify(w, h, &v_par_simd, &v_expected);
         }
-        if !is_x86_feature_detected!("fma") {
-            #[cfg(feature = "ispc")]
-            verify(w, h, &v_ispc, &v_expected);
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            // We don't want to check ISPC since it will use FMA, which will
+            // affect the accuracy of the results.
+            if is_x86_feature_detected!("fma") {
+                return
+            }
         }
+        #[cfg(feature = "ispc")]
+        verify(w, h, &v_ispc, &v_expected);
     }
 }

--- a/examples/mandelbrot/src/output.rs
+++ b/examples/mandelbrot/src/output.rs
@@ -20,7 +20,7 @@ pub mod ppm {
         (255.0, 170.0, 0.0),
         (0.0, 2.0, 0.0),
     ];
-    const SCALE: f32 = 12.0;
+    const SCALE: u32 = 12;
 
     pub fn write_header<O: io::Write>(o: &mut O, width: usize, height: usize) {
         writeln!(o, "P6\n{} {} 255", width, height).unwrap();
@@ -34,7 +34,7 @@ pub mod ppm {
         let (r, g, b) = if val == LIMIT {
             (0, 0, 0)
         } else {
-            let val = (val as f32 % SCALE) * (COLOURS.len() as f32) / SCALE;
+            let val = ((val % SCALE) as f32) * (COLOURS.len() as f32) / (SCALE as f32);
             let left = val as usize % COLOURS.len();
             let right = (left + 1) % COLOURS.len();
 

--- a/examples/mandelbrot/src/par_simd.rs
+++ b/examples/mandelbrot/src/par_simd.rs
@@ -48,7 +48,7 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
     let mut line_buffer = m.line_buffer(1);
     for i in 0..height {
         for j in (0..width).step_by(block_size) {
-            let ref val = out[i * width_in_blocks + j / block_size];
+            let val = &out[i * width_in_blocks + j / block_size];
             for k in 0..block_size {
                 out_fn(&mut line_buffer, j + k, val.extract(k));
             }

--- a/examples/mandelbrot/src/simd.rs
+++ b/examples/mandelbrot/src/simd.rs
@@ -49,22 +49,44 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
     );
 
     let height_step = m.height_step() as f64;
+    let height = m.height;
+    let block_size = u32s::lanes();
     let width_step = m.width_step() as f64;
+    let width = m.width;
+    let width_in_blocks = width / block_size;
     let out_fn = m.get_format_fn();
 
-    let mut adjust = f64s::splat(0.);
-    for i in 0..f64s::lanes() {
-        adjust = adjust.replace(i, i as f64);
-    }
+    let adjust = {
+        let mut adjust = f64s::splat(0.);
+        for i in 0..f64s::lanes() {
+            adjust = adjust.replace(i, i as f64);
+        }
+        adjust
+    };
+
+    let mut out = vec![u32s::splat(0); height * width_in_blocks];
+
+    let dur = time::Duration::span(|| {
+        for i in 0..height {
+            let y = f64s::splat(m.top as f64 + height_step * i as f64);
+            for j in (0..width).step_by(block_size) {
+                let offset = f64s::splat(j as f64) + adjust;
+                let x = f64s::splat(m.left as f64) + width_step * offset;
+                let val = simd::mandelbrot(x, y, limit);
+                let index = i * width_in_blocks + j / block_size;
+
+                out[index] = val;
+            }
+        }
+    });
+    eprintln!("simd: {} ms", dur.num_milliseconds());
+
     let mut line_buffer = m.line_buffer(1);
-    for i in 0..m.height {
-        let y = f64s::splat(m.top as f64 + height_step * i as f64);
-        for j in (0..m.width).step_by(f64s::lanes()) {
-            let offset: f64s = f64s::splat(j as f64) + adjust;
-            let x = f64s::splat(m.left as f64) + width_step * offset;
-            let ret = simd::mandelbrot(x, y, limit);
-            for k in 0..f64s::lanes() {
-                out_fn(&mut line_buffer, j + k, ret.extract(k));
+    for i in 0..height {
+        for j in (0..width).step_by(block_size) {
+            let ref val = out[i * width_in_blocks + j / block_size];
+            for k in 0..block_size {
+                out_fn(&mut line_buffer, j + k, val.extract(k));
             }
         }
         o.write_all(&line_buffer).unwrap();

--- a/examples/mandelbrot/src/simd.rs
+++ b/examples/mandelbrot/src/simd.rs
@@ -85,7 +85,7 @@ pub fn output<O: io::Write>(o: &mut O, m: &mut Mandelbrot, limit: u32) {
     let mut line_buffer = m.line_buffer(1);
     for i in 0..height {
         for j in (0..width).step_by(block_size) {
-            let ref val = out[i * width_in_blocks + j / block_size];
+            let val = &out[i * width_in_blocks + j / block_size];
             for k in 0..block_size {
                 out_fn(&mut line_buffer, j + k, val.extract(k));
             }


### PR DESCRIPTION
First, I refactored the benchmark code since IO was mixed with the math computation code, making it hard to determine what the issue was.

Next I did some perf improvements to match what ISPC was doing.

Some benchmarks with current progress (made after adding the commit which ignores I/O time):
```
simd (master): 616 ms
simd (this branch): 387 ms
ispc: 250 ms
```