### PR TITLE
Add `verify` tests for FMA (`mul_add`)

### DIFF
--- a/verify/verify/src/api.rs
+++ b/verify/verify/src/api.rs
@@ -1,1 +1,2 @@
+mod math;
 mod ops;

--- a/verify/verify/src/api/math.rs
+++ b/verify/verify/src/api/math.rs
@@ -1,0 +1,1 @@
+mod float;

--- a/verify/verify/src/api/math/float/mod.rs
+++ b/verify/verify/src/api/math/float/mod.rs
@@ -1,0 +1,1 @@
+mod mul_add;

--- a/verify/verify/src/api/math/float/mul_add.rs
+++ b/verify/verify/src/api/math/float/mul_add.rs
@@ -1,0 +1,85 @@
+mod f32x4 {
+    #![allow(unused)]
+    use packed_simd::*;
+    use stdsimd_test::assert_instr;
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfmadd)
+    )]
+    unsafe fn fused_multiply_add(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        a.mul_add(b, c)
+    }
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfmsub)
+    )]
+    unsafe fn fused_multiply_sub(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        a.mul_add(b, -c)
+    }
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfnmadd)
+    )]
+    unsafe fn fused_negate_multiply_add(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        a.mul_add(-b, c)
+    }
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfnmsub)
+    )]
+    unsafe fn fused_negate_multiply_sub(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        a.mul_add(-b, -c)
+    }
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfmaddsub)
+    )]
+    unsafe fn fused_multiply_add_sub(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        let add = a.mul_add(b, c);
+        let sub = a.mul_add(b, -c);
+
+        m32x4::new(false, true, false, true)
+            .select(add, sub)
+    }
+
+    #[inline]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature(enable = "sse,fma")
+    )]
+    #[cfg_attr(
+        any(target_arch = "x86", target_arch = "x86_64"), assert_instr(vfmsubadd)
+    )]
+    unsafe fn fused_multiply_sub_add(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
+        let add = a.mul_add(b, c);
+        let sub = a.mul_add(b, -c);
+
+        m32x4::new(true, false, true, false)
+            .select(add, sub)
+    }
+}


### PR DESCRIPTION
These tests verify that the proper FMA instruction gets selected when using `mul_add` in different scenarios.