### PR TITLE
Parallelize options pricing example

### DIFF
--- a/examples/options_pricing/benchmark.sh
+++ b/examples/options_pricing/benchmark.sh
@@ -25,10 +25,10 @@ if [[ "${NORUN}" == "1" ]]; then
     exit 0
 fi
 
-for alg in "${ALGS[@]}"
-do
-    hyperfine "target/release/options_pricing ${NUM_OPTIONS_BLACK_SCHOLES} ${alg}"
-done
+#for alg in "${ALGS[@]}"
+#do
+#    hyperfine "target/release/options_pricing ${NUM_OPTIONS_BLACK_SCHOLES} ${alg}"
+#done
 
 # Binomial put:
 ALGS=("binomial_put_scalar" "binomial_put_simd" "binomial_put_simd_par")

--- a/examples/options_pricing/benchmark.sh
+++ b/examples/options_pricing/benchmark.sh
@@ -4,17 +4,19 @@
 
 set -ex
 
-NUM_OPTIONS=10000000
+NUM_OPTIONS_BLACK_SCHOLES=10000000
 
 if [[ ${NORUN} != 1 ]]; then
     hash hyperfine 2>/dev/null || { echo >&2 "hyperfine is not in PATH."; exit 1; }
 fi
 
-ALGS=("black_scholes_scalar" "black_scholes_simd" "binomial_put_scalar" "binomial_put_simd")
+# Black-Scholes:
+ALGS=("black_scholes_scalar" "black_scholes_simd" "black_scholes_simd_par")
 if echo "$FEATURES" | grep -q "ispc"; then
     hash ispc 2>/dev/null || { echo >&2 "ispc is not in PATH."; exit 1; }
-    ALGS+=("black_scholes_ispc" "black_scholes_ispc_tasks" "binomial_put_ispc" "binomial_put_ispc_tasks")
+    ALGS+=("black_scholes_ispc" "black_scholes_ispc_tasks")
 fi
+
 
 RUSTFLAGS="-C target-cpu=native ${RUSTFLAGS}" \
          cargo build --release --features="${FEATURES}"
@@ -25,5 +27,18 @@ fi
 
 for alg in "${ALGS[@]}"
 do
-    hyperfine "target/release/options_pricing ${NUM_OPTIONS} ${alg}"
+    hyperfine "target/release/options_pricing ${NUM_OPTIONS_BLACK_SCHOLES} ${alg}"
+done
+
+# Binomial put:
+ALGS=("binomial_put_scalar" "binomial_put_simd" "binomial_put_simd_par")
+if echo "$FEATURES" | grep -q "ispc"; then
+    ALGS+=("binomial_put_ispc" "binomial_put_ispc_tasks")
+fi
+
+NUM_OPTIONS_BINOMIAL_PUT=500000
+
+for alg in "${ALGS[@]}"
+do
+    hyperfine "target/release/options_pricing ${NUM_OPTIONS_BINOMIAL_PUT} ${alg}"
 done

--- a/examples/options_pricing/build.rs
+++ b/examples/options_pricing/build.rs
@@ -27,8 +27,8 @@ fn main() {
                 ispc::opt::TargetISA::AVX512KNLi32x16,
             ]);
 
-
-            #[cfg(feature = "ispc_libm")] {
+            #[cfg(feature = "ispc_libm")]
+            {
                 // Use the system's libm
                 cfg.math_lib(ispc::opt::MathLib::System);
             }

--- a/examples/options_pricing/readme.md
+++ b/examples/options_pricing/readme.md
@@ -13,7 +13,37 @@ cargo run --release --features=ispc -- ${SIZE} ${ALGORITHM}
 
 ## Results
 
-TBD 
+```
+./benchmark.sh
+```
+
+## Black-Scholes
+
+On a dual core AVX1 i5 @1.8 GHz:
+
+| 800 x 800    | time [ms] <br> Rust | speedup vs `scalar` [-] |
+|--------------|---------------------|-------------------------|
+| `scalar`     |                998 | 1.0x                       |
+| `simd`       |                367 | 2.7x                       |
+| `par_simd`   |               246 | 4.1x                       |
+| `ispc`       |                360 | 2.8x                       |
+| `ispc+tasks` |               248 | 4.0x                       |
+
+`par_simd` and `ispc+tasks` algorithms are on par.
+
+## Binomial put
+
+On a dual core AVX1 i5 @1.8 GHz:
+
+| 800 x 800    | time [ms] <br> Rust | speedup vs `scalar` [-] |
+|--------------|---------------------|-------------------------|
+| `scalar`     |               2057 | 1.0x                       |
+| `simd`       |               1206 | 1.7x                       |
+| `par_simd`   |               484 | 4.3x                       |
+| `ispc`       |                805 | 2.6x                       |
+| `ispc+tasks` |               404 | 5.1x                       |
+
+`par_simd` algorithm is ~1.2x slower than `ispc+tasks`.
 
 
 [ispc]: https://github.com/ispc/ispc/tree/master/examples/options

--- a/examples/options_pricing/readme.md
+++ b/examples/options_pricing/readme.md
@@ -38,12 +38,12 @@ On a dual core AVX1 i5 @1.8 GHz:
 | 800 x 800    | time [ms] <br> Rust | speedup vs `scalar` [-] |
 |--------------|---------------------|-------------------------|
 | `scalar`     |               2057 | 1.0x                       |
-| `simd`       |               1206 | 1.7x                       |
-| `par_simd`   |               484 | 4.3x                       |
-| `ispc`       |                805 | 2.6x                       |
+| `simd`       |               651 | 3.2x                       |
+| `par_simd`   |               279 | 4.3x                       |
+| `ispc`       |                805 | 7.4x                       |
 | `ispc+tasks` |               404 | 5.1x                       |
 
-`par_simd` algorithm is ~1.2x slower than `ispc+tasks`.
+`par_simd` algorithm is ~1.4x faster than `ispc+tasks`.
 
 
 [ispc]: https://github.com/ispc/ispc/tree/master/examples/options

--- a/examples/options_pricing/src/lib.rs
+++ b/examples/options_pricing/src/lib.rs
@@ -27,6 +27,8 @@ const BINOMIAL_NUM: usize = 64;
 pub mod ispc_;
 pub mod scalar;
 pub mod simd;
+pub mod simd_kernels;
+pub mod simd_par;
 pub mod sum;
 
 #[derive(PartialEq, Debug)]

--- a/examples/options_pricing/src/lib.rs
+++ b/examples/options_pricing/src/lib.rs
@@ -8,7 +8,8 @@
         clippy::excessive_precision,
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap
+        clippy::cast_possible_wrap,
+        clippy::too_many_arguments
     )
 )]
 extern crate packed_simd;

--- a/examples/options_pricing/src/lib.rs
+++ b/examples/options_pricing/src/lib.rs
@@ -15,7 +15,7 @@ extern crate packed_simd;
 extern crate rayon;
 
 use packed_simd::f32x8 as f32s;
-// use packed_simd::f64x8 as f64s;
+use packed_simd::f64x8 as f64s;
 
 #[cfg(feature = "ispc")]
 #[macro_use]

--- a/examples/options_pricing/src/main.rs
+++ b/examples/options_pricing/src/main.rs
@@ -73,6 +73,12 @@ fn main() {
         "binomial_put_simd" => {
             run("binomial_put_simd", num_options, simd::binomial_put)
         }
+        "black_scholes_simd_par" => {
+            run("black_scholes_simd_par", num_options, simd_par::black_scholes)
+        }
+        "binomial_put_simd_par" => {
+            run("binomial_put_simd_par", num_options, simd_par::binomial_put)
+        }
         _ => panic!("unknown algorithm: {}", algorithm),
     }
 }

--- a/examples/options_pricing/src/scalar.rs
+++ b/examples/options_pricing/src/scalar.rs
@@ -38,7 +38,7 @@ pub fn black_scholes(
         let d2 = d1 - v * t.sqrt();
         result[i] = s * cnd(d1) - x * (-r * t).exp() * cnd(d2);
     }
-    ::sum::sum_slice(&result)
+    ::sum::slice_scalar(&result)
 }
 
 pub fn binomial_put(
@@ -75,7 +75,7 @@ pub fn binomial_put(
 
         result[i] = vs[0];
     }
-    ::sum::sum_slice(&result)
+    ::sum::slice_scalar(&result)
 }
 
 #[cfg(feature = "ispc")]

--- a/examples/options_pricing/src/scalar.rs
+++ b/examples/options_pricing/src/scalar.rs
@@ -38,7 +38,7 @@ pub fn black_scholes(
         let d2 = d1 - v * t.sqrt();
         result[i] = s * cnd(d1) - x * (-r * t).exp() * cnd(d2);
     }
-    ::sum::fastest(&result)
+    ::sum::sum_slice(&result)
 }
 
 pub fn binomial_put(
@@ -75,7 +75,7 @@ pub fn binomial_put(
 
         result[i] = vs[0];
     }
-    ::sum::fastest(&result)
+    ::sum::sum_slice(&result)
 }
 
 #[cfg(feature = "ispc")]

--- a/examples/options_pricing/src/simd.rs
+++ b/examples/options_pricing/src/simd.rs
@@ -2,9 +2,12 @@
 
 use f32s;
 
-pub fn serial<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
-                 result: &mut [f32], count: usize, kernel: K) -> f64
-    where K: Fn(f32s, f32s, f32s, f32s, f32s) -> f32s
+pub fn serial<K>(
+    sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
+    result: &mut [f32], count: usize, kernel: K,
+) -> f64
+where
+    K: Fn(f32s, f32s, f32s, f32s, f32s) -> f32s,
 {
     assert_eq!(count % f32s::lanes(), 0);
     for i in (0..count).step_by(f32s::lanes()) {
@@ -37,8 +40,8 @@ pub fn binomial_put(
 
 #[cfg(test)]
 mod tests {
-    use almost_equal;
     use super::*;
+    use almost_equal;
     #[test]
     fn black_scholes_scalar() {
         const NOPTS: usize = 1_000_000;

--- a/examples/options_pricing/src/simd.rs
+++ b/examples/options_pricing/src/simd.rs
@@ -18,7 +18,7 @@ pub fn serial<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
             r.write_to_slice_unaligned_unchecked(&mut result[i..]);
         }
     }
-    ::sum::fastest(&result)
+    ::sum::sum_slice(&result)
 }
 
 pub fn black_scholes(

--- a/examples/options_pricing/src/simd.rs
+++ b/examples/options_pricing/src/simd.rs
@@ -21,7 +21,7 @@ where
             r.write_to_slice_unaligned_unchecked(&mut result[i..]);
         }
     }
-    ::sum::sum_slice(&result)
+    ::sum::slice(&result)
 }
 
 pub fn black_scholes(

--- a/examples/options_pricing/src/simd_kernels.rs
+++ b/examples/options_pricing/src/simd_kernels.rs
@@ -1,0 +1,55 @@
+use f32s;
+
+// Cumulative normal distribution function
+#[inline(always)]
+pub fn cnd(x: f32s) -> f32s {
+    const INV_SQRT_2PI: f32s = f32s::splat(0.398_942_280_40);
+
+    let l = x.abs();
+    let k = 1. / (1. + 0.231_641_9 * l);
+    let k2 = k * k;
+    let k3 = k2 * k;
+    let k4 = k2 * k2;
+    let k5 = k3 * k2;
+    let w: f32s = 0.319_381_53 * k - 0.356_563_782 * k2
+        + 1.781_477_937 * k3
+        + -1.821_255_978 * k4
+        + 1.330_274_429 * k5;
+    let w = w * INV_SQRT_2PI * (-l * l * 0.5).exp();
+
+    x.gt(f32s::splat(0.)).select(1. - w, w)
+}
+
+#[inline(always)]
+pub fn black_scholes(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
+    let d1 = ((s / x).ln() + (r + v * v * 0.5) * t) / (v * t.sqrt());
+    let d2 = d1 - v * t.sqrt();
+    s * cnd(d1) - x * (-r * t).exp() * cnd(d2)
+}
+
+
+#[inline(always)]
+pub fn binomial_put(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
+    use BINOMIAL_NUM;
+
+    let dt = t / BINOMIAL_NUM as f32;
+    let u = (v * dt.sqrt()).exp();
+    let d = 1. / u;
+    let disc = (r * dt).exp();
+    let pu = (disc - d) / (u - d);
+
+    let mut vs = [f32s::splat(0.); BINOMIAL_NUM];
+    for (j, v) in vs.iter_mut().enumerate() {
+        let e = (2_i32 * (j as i32)).wrapping_sub(BINOMIAL_NUM as i32);
+        let upow = u.powf(f32s::splat(e as f32));
+        *v = f32s::splat(0.).max(x - s * upow);
+    }
+
+    for j in (0..BINOMIAL_NUM).rev() {
+        for k in 0..j {
+            vs[k] = ((1. - pu) * vs[k] + pu * vs[k + 1]) / disc;
+        }
+    }
+
+    vs[0]
+}

--- a/examples/options_pricing/src/simd_kernels.rs
+++ b/examples/options_pricing/src/simd_kernels.rs
@@ -35,7 +35,9 @@ pub fn binomial_put(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
     let u = (v * dt.sqrt()).exp();
     let d = 1. / u;
     let disc = (r * dt).exp();
+    let inv_disc = 1. / disc;
     let pu = (disc - d) / (u - d);
+    let o_m_pu = 1. - pu;
 
     let mut vs = [f32s::splat(0.); BINOMIAL_NUM];
     for (j, v) in vs.iter_mut().enumerate() {
@@ -46,7 +48,7 @@ pub fn binomial_put(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
 
     for j in (0..BINOMIAL_NUM).rev() {
         for k in 0..j {
-            vs[k] = ((1. - pu) * vs[k] + pu * vs[k + 1]) / disc;
+            vs[k] = (o_m_pu * vs[k] + pu * vs[k + 1]) * inv_disc;
         }
     }
 

--- a/examples/options_pricing/src/simd_kernels.rs
+++ b/examples/options_pricing/src/simd_kernels.rs
@@ -27,7 +27,6 @@ pub fn black_scholes(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
     s * cnd(d1) - x * (-r * t).exp() * cnd(d2)
 }
 
-
 #[inline(always)]
 pub fn binomial_put(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
     use BINOMIAL_NUM;

--- a/examples/options_pricing/src/simd_par.rs
+++ b/examples/options_pricing/src/simd_par.rs
@@ -23,7 +23,7 @@ pub fn parallel<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
             r.write_to_slice_unaligned_unchecked(result);
         }
     });
-    ::sum::fastest(&result)
+    ::sum::sum_slice(&result)
 }
 
 pub fn black_scholes(

--- a/examples/options_pricing/src/simd_par.rs
+++ b/examples/options_pricing/src/simd_par.rs
@@ -25,7 +25,7 @@ where
             }
         },
     );
-    ::sum::sum_slice(&result)
+    ::sum::slice(&result)
 }
 
 pub fn black_scholes(

--- a/examples/options_pricing/src/simd_par.rs
+++ b/examples/options_pricing/src/simd_par.rs
@@ -2,12 +2,17 @@
 
 use f32s;
 
-pub fn serial<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
+pub fn parallel<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
                  result: &mut [f32], count: usize, kernel: K) -> f64
-    where K: Fn(f32s, f32s, f32s, f32s, f32s) -> f32s
+    where K: Fn(f32s, f32s, f32s, f32s, f32s) -> f32s + Sync + Send
 {
+    use ::rayon::prelude::*;
     assert_eq!(count % f32s::lanes(), 0);
-    for i in (0..count).step_by(f32s::lanes()) {
+    result
+        .par_chunks_mut(f32s::lanes())
+        .enumerate()
+        .for_each(|(i, result)| {
+            debug_assert!(result.len() == 8);
         unsafe {
             let s = f32s::from_slice_unaligned_unchecked(&sa[i..]);
             let x = f32s::from_slice_unaligned_unchecked(&xa[i..]);
@@ -15,9 +20,9 @@ pub fn serial<K>(sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
             let r = f32s::from_slice_unaligned_unchecked(&ra[i..]);
             let v = f32s::from_slice_unaligned_unchecked(&va[i..]);
             let r = kernel(s, x, t, r, v);
-            r.write_to_slice_unaligned_unchecked(&mut result[i..]);
+            r.write_to_slice_unaligned_unchecked(result);
         }
-    }
+    });
     ::sum::fastest(&result)
 }
 
@@ -25,44 +30,45 @@ pub fn black_scholes(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    serial(sa, xa, ta, ra, va, result, count, ::simd_kernels::black_scholes)
+    parallel(sa, xa, ta, ra, va, result, count, ::simd_kernels::black_scholes)
 }
 
 pub fn binomial_put(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    serial(sa, xa, ta, ra, va, result, count, ::simd_kernels::binomial_put)
+    parallel(sa, xa, ta, ra, va, result, count, ::simd_kernels::binomial_put)
 }
 
 #[cfg(test)]
 mod tests {
-    use almost_equal;
     use super::*;
+    use almost_equal;
     #[test]
     fn black_scholes_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd = ::State::new(NOPTS);
+        let mut simd_par = ::State::new(NOPTS);
         let mut scalar = ::State::new(NOPTS);
 
-        let simd_sum = simd.exec(black_scholes);
+        let simd_par_sum = simd_par.exec(black_scholes);
         let scalar_sum = scalar.exec(::scalar::black_scholes);
 
-        assert_eq!(simd, scalar);
-        assert_eq!(simd_sum, scalar_sum);
+        assert_eq!(simd_par, scalar);
+        assert_eq!(simd_par_sum, scalar_sum);
     }
 
     #[test]
     fn binomial_put_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd = ::State::new(NOPTS);
+        let mut simd_par = ::State::new(NOPTS);
         let mut scalar = ::State::new(NOPTS);
 
-        let simd_sum = simd.exec(binomial_put);
+        let simd_par_sum = simd_par.exec(binomial_put);
         let scalar_sum = scalar.exec(::scalar::binomial_put);
 
-        // assert_eq!(simd, scalar);
-        // assert_eq!(simd_sum, scalar_sum);
-        assert!(almost_equal(simd_sum, scalar_sum, 1e-5));
+        // assert_eq!(simd_par, scalar);
+        // assert_eq!(simd_par_sum, scalar_sum);
+        assert!(almost_equal(simd_par_sum, scalar_sum, 1e-5));
     }
 }
+

--- a/examples/options_pricing/src/sum.rs
+++ b/examples/options_pricing/src/sum.rs
@@ -2,7 +2,7 @@
 
 use super::{f32s, f64s};
 
-pub fn sum_slice(x: &[f32]) -> f64 {
+pub fn slice(x: &[f32]) -> f64 {
     assert_eq!(f32s::lanes(), f64s::lanes());
     assert_eq!(x.len() % f32s::lanes(), 0);
 
@@ -15,4 +15,12 @@ pub fn sum_slice(x: &[f32]) -> f64 {
         }
     }
     sum.sum()
+}
+
+pub fn slice_scalar(x: &[f32]) -> f64 {
+    let mut sum = 0_f64;
+    for &x in x {
+        sum += f64::from(x);
+    }
+    sum
 }

--- a/examples/options_pricing/src/sum.rs
+++ b/examples/options_pricing/src/sum.rs
@@ -1,53 +1,18 @@
 //! Implements different algorithms for summing a slice of `f32`s
 
-use super::f32s;
-use rayon::prelude::*;
-use std::{mem, slice};
+use super::{f32s, f64s};
 
-pub fn scalar(x: &[f32]) -> f32 {
-    x.iter().sum()
-}
-
-pub fn vector(x: &[f32]) -> f32 {
+pub fn sum_slice(x: &[f32]) -> f64 {
+    assert_eq!(f32s::lanes(), f64s::lanes());
     assert_eq!(x.len() % f32s::lanes(), 0);
 
-    let mut sum = f32s::splat(0.);
+    let mut sum = f64s::splat(0.);
     for i in (0..x.len()).step_by(f32s::lanes()) {
-        sum += f32s::from_slice_unaligned(&x[i..]);
+        unsafe {
+            use packed_simd::Cast;
+            let v: f64s = f32s::from_slice_unaligned_unchecked(&x[i..]).cast();
+            sum += v;
+        }
     }
     sum.sum()
-}
-
-pub fn vector_par(x: &[f32]) -> f32 {
-    let len: usize = x.len();
-    assert_eq!(len % 8, 0);
-
-    // find the first properly aligned element
-    let (i, _): (usize, _) = x
-        .iter()
-        .enumerate()
-        .find(|&(_, y): &(usize, &f32)| {
-            (y as *const f32) as usize % mem::align_of::<f32s>() == 0
-        }).unwrap();
-
-    let (head, tail) = x.split_at(i);
-    let head_sum: f32 = head.iter().sum();
-
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
-    let tail: &[f32s] = unsafe {
-        slice::from_raw_parts(
-            tail.as_ptr() as *const f32s,
-            tail.len() / f32s::lanes(),
-        )
-    };
-    let tail_sum: f32s = tail.into_par_iter().sum();
-    head_sum + tail_sum.sum()
-}
-
-pub fn fastest(x: &[f32]) -> f64 {
-    let mut sum = 0_f64;
-    for &x in x {
-        sum += f64::from(x);
-    }
-    sum
 }

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,9 @@ slowdown:
 * `aobench`: `[-1.02x, +1.53x]`,
 * `stencil`: `[+1.06x, +1.72x]`,
 * `mandelbrot`: `[-1.74x, +1.2x]`,
-* `options_pricing`: TBD,
+* `options_pricing`:
+   * `black_scholes`: +`1.0x` 
+   * `binomial_put`: -`1.2x` 
 
  While SPMD is not the intended use case for `packed_simd`, it is possible to
  combine the library with [`rayon`][rayon] to poorly emulate [ISPC]'s SPMD programming

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,8 @@ slowdown:
 * `stencil`: `[+1.06x, +1.72x]`,
 * `mandelbrot`: `[-1.74x, +1.2x]`,
 * `options_pricing`:
-   * `black_scholes`: +`1.0x` 
-   * `binomial_put`: -`1.2x` 
+   * `black_scholes`: `+1.0x` 
+   * `binomial_put`: `+1.4x` 
 
  While SPMD is not the intended use case for `packed_simd`, it is possible to
  combine the library with [`rayon`][rayon] to poorly emulate [ISPC]'s SPMD programming


### PR DESCRIPTION
It's possible to beat ISPC by just moving around some computations in the binomial put kernel (e.g. using `inv_disc = 1. / disc`, `one_minus_pu = 1. - pu`, etc. , but ISPC does not do this and is still faster for some reason. AFAICT LLVM is not allowed to do these re-orderings because doing so would affect the results.