### PR TITLE
Implement shuffle1_dyn for all vector types

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -78,6 +78,7 @@ macro_rules! impl_i {
         impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_swap_bytes!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_cmp_partial_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
         impl_cmp_eq!([$elem_ty; $elem_n]: $tuple_id | $test_tt | (0, 1));
         impl_cmp_vertical!(
@@ -88,6 +89,7 @@ macro_rules! impl_i {
 
         test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
         test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
     }
 }
 
@@ -146,6 +148,7 @@ macro_rules! impl_u {
 
         test_select!($elem_ty, $mask_ty, $tuple_id, (1, 2) | $test_tt);
         test_cmp_partial_ord_int!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
     }
 }
 
@@ -177,6 +180,7 @@ macro_rules! impl_f {
         );
         impl_slice_from_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
         impl_slice_write_to_slice!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
 
         // floating-point math
         impl_math_float_abs!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
@@ -199,6 +203,7 @@ macro_rules! impl_f {
         test_reduction_float_min_max!(
             [$elem_ty; $elem_n]: $tuple_id | $test_tt
         );
+        test_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
     }
 }
 
@@ -243,8 +248,10 @@ macro_rules! impl_m {
         impl_cmp_ord!(
             [$elem_ty; $elem_n]: $tuple_id | $test_tt | (false, true)
         );
+        impl_shuffle1_dyn!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
 
         test_cmp_partial_ord_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
+        test_shuffle1_dyn_mask!([$elem_ty; $elem_n]: $tuple_id | $test_tt);
     }
 }
 

--- a/src/api/cast/v128.rs
+++ b/src/api/cast/v128.rs
@@ -60,9 +60,6 @@ impl_from_cast_mask!(
     i64x2, u64x2, f64x2, i128x2, u128x2, m128x2, isizex2, usizex2, msizex2
 );
 
-// FIXME[test_v128]: 64-bit single element vectors into_cast impls
-// e.g. impls for _128x1 for e.g. _64x1
-
 impl_from_cast!(
     isizex2[test_v128]: i8x2, u8x2, m8x2, i16x2, u16x2, m16x2, i32x2, u32x2, f32x2, m32x2,
     i64x2, u64x2, f64x2, m64x2, i128x2, u128x2, m128x2, usizex2, msizex2
@@ -75,3 +72,8 @@ impl_from_cast_mask!(
     msizex2[test_v128]: i8x2, u8x2, m8x2, i16x2, u16x2, m16x2, i32x2, u32x2, f32x2, m32x2,
     i64x2, u64x2, f64x2, m64x2, i128x2, u128x2, m128x2, isizex2, usizex2
 );
+
+// FIXME[test_v128]: 64-bit single element vectors into_cast impls
+impl_from_cast!(i128x1[test_v128]: u128x1, m128x1);
+impl_from_cast!(u128x1[test_v128]: i128x1, m128x1);
+impl_from_cast!(m128x1[test_v128]: i128x1, u128x1);

--- a/src/api/shuffle1_dyn.rs
+++ b/src/api/shuffle1_dyn.rs
@@ -5,11 +5,18 @@ macro_rules! impl_shuffle1_dyn {
         impl $id {
             /// Shuffle vector elements according to `indices`.
             #[inline]
-            pub fn shuffle1_dyn(self, indices: Self) -> Self {
+            pub fn shuffle1_dyn<I>(self, indices: I) -> Self
+            where
+                Self: codegen::shuffle1_dyn::Shuffle1Dyn<Indices = I>,
+            {
                 codegen::shuffle1_dyn::Shuffle1Dyn::shuffle1_dyn(self, indices)
             }
         }
+    };
+}
 
+macro_rules! test_shuffle1_dyn {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
         test_if! {
             $test_tt:
             interpolate_idents! {
@@ -18,37 +25,96 @@ macro_rules! impl_shuffle1_dyn {
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn shuffle1_dyn() {
                         let increasing = {
-                            let mut v = $id::splat(0);
+                            let mut v = $id::splat(0 as $elem_ty);
                             for i in 0..$id::lanes() {
                                 v = v.replace(i, i as $elem_ty);
                             }
                             v
                         };
                         let decreasing = {
-                            let mut v = $id::splat(0);
+                            let mut v = $id::splat(0 as $elem_ty);
                             for i in 0..$id::lanes() {
                                 v = v.replace(i, ($id::lanes() - 1 - i) as $elem_ty);
                             }
                             v
                         };
 
-                        assert_eq!(increasing.shuffle1_dyn(increasing), increasing, "(i,i)=>i");
-                        assert_eq!(decreasing.shuffle1_dyn(increasing), decreasing, "(d,i)=>d");
-                        assert_eq!(increasing.shuffle1_dyn(decreasing), decreasing, "(i,d)=>d");
-                        assert_eq!(decreasing.shuffle1_dyn(decreasing), increasing, "(d,d)=>i");
+                        type Indices = <$id as codegen::shuffle1_dyn::Shuffle1Dyn>::Indices;
+                        let increasing_ids: Indices = increasing.cast();
+                        let decreasing_ids: Indices = decreasing.cast();
+
+                        assert_eq!(increasing.shuffle1_dyn(increasing_ids), increasing, "(i,i)=>i");
+                        assert_eq!(decreasing.shuffle1_dyn(increasing_ids), decreasing, "(d,i)=>d");
+                        assert_eq!(increasing.shuffle1_dyn(decreasing_ids), decreasing, "(i,d)=>d");
+                        assert_eq!(decreasing.shuffle1_dyn(decreasing_ids), increasing, "(d,d)=>i");
 
                         for i in 0..$id::lanes() {
-                            assert_eq!(increasing.shuffle1_dyn($id::splat(i as $elem_ty)),
+                            let v_ids: Indices = $id::splat(i as $elem_ty).cast();
+                            assert_eq!(increasing.shuffle1_dyn(v_ids),
                                        $id::splat(increasing.extract(i)));
-                            assert_eq!(decreasing.shuffle1_dyn($id::splat(i as $elem_ty)),
+                            assert_eq!(decreasing.shuffle1_dyn(v_ids),
                                        $id::splat(decreasing.extract(i)));
 
-                            assert_eq!($id::splat(i as $elem_ty).shuffle1_dyn(increasing),
+                            assert_eq!($id::splat(i as $elem_ty).shuffle1_dyn(increasing_ids),
                                        $id::splat(i as $elem_ty));
-                            assert_eq!($id::splat(i as $elem_ty).shuffle1_dyn(decreasing),
+                            assert_eq!($id::splat(i as $elem_ty).shuffle1_dyn(decreasing_ids),
                                        $id::splat(i as $elem_ty));
                         }
 
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! test_shuffle1_dyn_mask {
+    ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
+        test_if! {
+            $test_tt:
+            interpolate_idents! {
+                pub mod [$id _shuffle1_dyn] {
+                    use super::*;
+                    #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+                    fn shuffle1_dyn() {
+                        // alternating = [true, false, true, false, ...]
+                        let mut alternating = $id::splat(false);
+                        for i in 0..$id::lanes() {
+                            if i % 2 == 0 {
+                                alternating = alternating.replace(i, true);
+                            }
+                        }
+
+                        type Indices = <$id as codegen::shuffle1_dyn::Shuffle1Dyn>::Indices;
+                        // even = [0, 0, 2, 2, 4, 4, ..]
+                        let even = {
+                            let mut v = Indices::splat(0);
+                            for i in 0..$id::lanes() {
+                                if i % 2 == 0 {
+                                    v = v.replace(i, (i as u8).into());
+                                } else {
+                                    v = v.replace(i, (i as u8 - 1).into());
+                                }
+                            }
+                            v
+                        };
+                        // odd = [1, 1, 3, 3, 5, 5, ...]
+                        let odd = {
+                            let mut v = Indices::splat(0);
+                            for i in 0..$id::lanes() {
+                                if i % 2 != 0 {
+                                    v = v.replace(i, (i as u8).into());
+                                } else {
+                                    v = v.replace(i, (i as u8 + 1).into());
+                                }
+                            }
+                            v
+                        };
+
+                        assert_eq!(alternating.shuffle1_dyn(even), $id::splat(true));
+                        if $id::lanes() > 1 {
+                            assert_eq!(alternating.shuffle1_dyn(odd), $id::splat(false));
+                        }
                     }
                 }
             }

--- a/src/codegen/math/float/powf.rs
+++ b/src/codegen/math/float/powf.rs
@@ -41,7 +41,12 @@ macro_rules! impl_vpowf {
         impl Powf for $vid {
             #[inline]
             fn powf(self, e: Self) -> Self {
-                unsafe { mem::transmute($llvm_fn(mem::transmute(self), mem::transmute(e))) }
+                unsafe {
+                    mem::transmute($llvm_fn(
+                        mem::transmute(self),
+                        mem::transmute(e),
+                    ))
+                }
             }
         }
     };

--- a/src/codegen/shuffle1_dyn.rs
+++ b/src/codegen/shuffle1_dyn.rs
@@ -2,16 +2,18 @@
 
 use *;
 
-crate trait Shuffle1Dyn {
-    fn shuffle1_dyn(self, Self) -> Self;
+pub trait Shuffle1Dyn {
+    type Indices;
+    fn shuffle1_dyn(self, Self::Indices) -> Self;
 }
 
 // Fallback implementation
 macro_rules! impl_fallback {
     ($id:ident) => {
         impl Shuffle1Dyn for $id {
+            type Indices = Self;
             #[inline]
-            fn shuffle1_dyn(self, indices: Self) -> Self {
+            fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                 let mut result = Self::splat(0);
                 for i in 0..$id::lanes() {
                     result = result
@@ -29,8 +31,9 @@ macro_rules! impl_shuffle1_dyn {
             if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
                          target_feature = "ssse3"))] {
                 impl Shuffle1Dyn for u8x8 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
                         use arch::x86::_mm_shuffle_pi8;
                         #[cfg(target_arch = "x86_64")]
@@ -50,8 +53,9 @@ macro_rules! impl_shuffle1_dyn {
                 feature = "coresimd")
             )] {
                 impl Shuffle1Dyn for u8x8 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(targt_arch = "aarch64")]
                         use arch::aarch64::vtbl1_u8;
                         #[cfg(targt_arch = "arm")]
@@ -78,8 +82,9 @@ macro_rules! impl_shuffle1_dyn {
             if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
                          target_feature = "ssse3"))] {
                 impl Shuffle1Dyn for u8x16 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
                         use arch::x86::_mm_shuffle_epi8;
                         #[cfg(target_arch = "x86_64")]
@@ -98,8 +103,9 @@ macro_rules! impl_shuffle1_dyn {
             } else if #[cfg(all(target_aarch = "aarch64", target_feature = "neon",
                                 feature = "coresimd"))] {
                 impl Shuffle1Dyn for u8x16 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         use arch::aarch64::vqtbl1q_u8;
 
                         // This is safe because the binary is compiled with
@@ -116,8 +122,9 @@ macro_rules! impl_shuffle1_dyn {
             } else if #[cfg(all(target_aarch = "arm", target_feature = "v7",
                                 target_feature = "neon", feature = "coresimd"))] {
                 impl Shuffle1Dyn for u8x16 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         use arch::arm::vtbl2_u8;
 
                         // This is safe because the binary is compiled with
@@ -147,8 +154,9 @@ macro_rules! impl_shuffle1_dyn {
     };
     (u16x8) => {
         impl Shuffle1Dyn for u16x8 {
+            type Indices = Self;
             #[inline]
-            fn shuffle1_dyn(self, indices: Self) -> Self {
+            fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                 let indices: u8x8 = (indices * 2).cast();
                 let indices: u8x16 = shuffle!(indices, [0, 0, 1, 1, 2, 2, 3, 3,
                                                         4, 4, 5, 5, 6, 6, 7, 7]);
@@ -166,8 +174,9 @@ macro_rules! impl_shuffle1_dyn {
             if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
                          target_feature = "avx"))] {
                 impl Shuffle1Dyn for u32x4 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
                         use arch::x86::{_mm_permutevar_ps};
                         #[cfg(target_arch = "x86_64")]
@@ -182,8 +191,9 @@ macro_rules! impl_shuffle1_dyn {
                 }
             } else {
                 impl Shuffle1Dyn for u32x4 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         let indices: u8x4 = (indices * 4).cast();
                         let indices: u8x16 = shuffle!(indices, [0, 0, 0, 0, 1, 1, 1, 1,
                                                                 2, 2, 2, 2, 3, 3, 3, 3]);
@@ -203,8 +213,9 @@ macro_rules! impl_shuffle1_dyn {
             if #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"),
                          target_feature = "avx"))] {
                 impl Shuffle1Dyn for u64x2 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
                         use arch::x86::{_mm_permutevar_pd};
                         #[cfg(target_arch = "x86_64")]
@@ -222,8 +233,9 @@ macro_rules! impl_shuffle1_dyn {
                 }
             } else {
                 impl Shuffle1Dyn for u64x2 {
+                    type Indices = Self;
                     #[inline]
-                    fn shuffle1_dyn(self, indices: Self) -> Self {
+                    fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         let indices: u8x2 = (indices * 8).cast();
                         let indices: u8x16 = shuffle!(indices, [0, 0, 0, 0, 0, 0, 0, 0,
                                                                 1, 1, 1, 1, 1, 1, 1, 1]);
@@ -240,8 +252,9 @@ macro_rules! impl_shuffle1_dyn {
     };
     (u128x1) => {
         impl Shuffle1Dyn for u128x1 {
+            type Indices = Self;
             #[inline]
-            fn shuffle1_dyn(self, _indices: Self) -> Self {
+            fn shuffle1_dyn(self, _indices: Self::Indices) -> Self {
                 self
             }
         }
@@ -278,3 +291,112 @@ impl_shuffle1_dyn!(usizex8);
 impl_shuffle1_dyn!(u128x1);
 impl_shuffle1_dyn!(u128x2);
 impl_shuffle1_dyn!(u128x4);
+
+// Implementation for non-unsigned vector types
+macro_rules! impl_shuffle1_dyn_non_u {
+    ($id:ident, $uid:ident) => {
+        impl Shuffle1Dyn for $id {
+            type Indices = $uid;
+            #[inline]
+            fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
+                unsafe {
+                    let u: $uid = mem::transmute(self);
+                    mem::transmute(u.shuffle1_dyn(indices))
+                }
+            }
+        }
+    };
+}
+
+impl_shuffle1_dyn_non_u!(i8x2, u8x2);
+impl_shuffle1_dyn_non_u!(i8x4, u8x4);
+impl_shuffle1_dyn_non_u!(i8x8, u8x8);
+impl_shuffle1_dyn_non_u!(i8x16, u8x16);
+impl_shuffle1_dyn_non_u!(i8x32, u8x32);
+impl_shuffle1_dyn_non_u!(i8x64, u8x64);
+
+impl_shuffle1_dyn_non_u!(i16x2, u16x2);
+impl_shuffle1_dyn_non_u!(i16x4, u16x4);
+impl_shuffle1_dyn_non_u!(i16x8, u16x8);
+impl_shuffle1_dyn_non_u!(i16x16, u16x16);
+impl_shuffle1_dyn_non_u!(i16x32, u16x32);
+
+impl_shuffle1_dyn_non_u!(i32x2, u32x2);
+impl_shuffle1_dyn_non_u!(i32x4, u32x4);
+impl_shuffle1_dyn_non_u!(i32x8, u32x8);
+impl_shuffle1_dyn_non_u!(i32x16, u32x16);
+
+impl_shuffle1_dyn_non_u!(i64x2, u64x2);
+impl_shuffle1_dyn_non_u!(i64x4, u64x4);
+impl_shuffle1_dyn_non_u!(i64x8, u64x8);
+
+impl_shuffle1_dyn_non_u!(isizex2, usizex2);
+impl_shuffle1_dyn_non_u!(isizex4, usizex4);
+impl_shuffle1_dyn_non_u!(isizex8, usizex8);
+
+impl_shuffle1_dyn_non_u!(i128x1, u128x1);
+impl_shuffle1_dyn_non_u!(i128x2, u128x2);
+impl_shuffle1_dyn_non_u!(i128x4, u128x4);
+
+impl_shuffle1_dyn_non_u!(m8x2, u8x2);
+impl_shuffle1_dyn_non_u!(m8x4, u8x4);
+impl_shuffle1_dyn_non_u!(m8x8, u8x8);
+impl_shuffle1_dyn_non_u!(m8x16, u8x16);
+impl_shuffle1_dyn_non_u!(m8x32, u8x32);
+impl_shuffle1_dyn_non_u!(m8x64, u8x64);
+
+impl_shuffle1_dyn_non_u!(m16x2, u16x2);
+impl_shuffle1_dyn_non_u!(m16x4, u16x4);
+impl_shuffle1_dyn_non_u!(m16x8, u16x8);
+impl_shuffle1_dyn_non_u!(m16x16, u16x16);
+impl_shuffle1_dyn_non_u!(m16x32, u16x32);
+
+impl_shuffle1_dyn_non_u!(m32x2, u32x2);
+impl_shuffle1_dyn_non_u!(m32x4, u32x4);
+impl_shuffle1_dyn_non_u!(m32x8, u32x8);
+impl_shuffle1_dyn_non_u!(m32x16, u32x16);
+
+impl_shuffle1_dyn_non_u!(m64x2, u64x2);
+impl_shuffle1_dyn_non_u!(m64x4, u64x4);
+impl_shuffle1_dyn_non_u!(m64x8, u64x8);
+
+impl_shuffle1_dyn_non_u!(msizex2, usizex2);
+impl_shuffle1_dyn_non_u!(msizex4, usizex4);
+impl_shuffle1_dyn_non_u!(msizex8, usizex8);
+
+impl_shuffle1_dyn_non_u!(m128x1, u128x1);
+impl_shuffle1_dyn_non_u!(m128x2, u128x2);
+impl_shuffle1_dyn_non_u!(m128x4, u128x4);
+
+impl_shuffle1_dyn_non_u!(f32x2, u32x2);
+impl_shuffle1_dyn_non_u!(f32x4, u32x4);
+impl_shuffle1_dyn_non_u!(f32x8, u32x8);
+impl_shuffle1_dyn_non_u!(f32x16, u32x16);
+
+impl_shuffle1_dyn_non_u!(f64x2, u64x2);
+impl_shuffle1_dyn_non_u!(f64x4, u64x4);
+impl_shuffle1_dyn_non_u!(f64x8, u64x8);
+
+// Implementation for non-unsigned vector types
+macro_rules! impl_shuffle1_dyn_ptr {
+    ($id:ident, $uid:ident) => {
+        impl<T> Shuffle1Dyn for $id<T> {
+            type Indices = $uid;
+            #[inline]
+            fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
+                unsafe {
+                    let u: $uid = mem::transmute(self);
+                    mem::transmute(u.shuffle1_dyn(indices))
+                }
+            }
+        }
+    };
+}
+
+impl_shuffle1_dyn_ptr!(cptrx2, usizex2);
+impl_shuffle1_dyn_ptr!(cptrx4, usizex4);
+impl_shuffle1_dyn_ptr!(cptrx8, usizex8);
+
+impl_shuffle1_dyn_ptr!(mptrx2, usizex2);
+impl_shuffle1_dyn_ptr!(mptrx4, usizex4);
+impl_shuffle1_dyn_ptr!(mptrx8, usizex8);


### PR DESCRIPTION
`shuffle1_dyn` was only implemented for unsigned integer vectors. This PR implements it for signed-integer, floating-point, masks, and pointer vectors.

Closes #151.