### PR TITLE
Fix compilation on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@
 
 #![feature(
     rust_2018_preview,
+    crate_visibility_modifier,
     repr_simd,
     const_fn,
     platform_intrinsics,


### PR DESCRIPTION
Should fix CI. This was introduced by [this commit to rust-lang](https://github.com/rust-lang/rust/commit/5af06768a9b80afd9c1b8bbed695152d4ac5d9db)