### PR TITLE
Add a triangle transformation example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
       name: "aarch64-unknown-linux-android + NEON"
     # Linux:
-    - env: TARGET=i586-unknown-linux-gnu
+    - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse"
       name: "i586-unknown-linux-gnu + SSE"
     - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse2"
       name: "i586-unknown-linux-gnu + SSE2"
@@ -137,7 +137,7 @@ matrix:
     # Solaris:
     #- env: TARGET=x86_64-sun-solaris NORUN=1
     #  script: ci/run.sh
-    # iOS: 
+    # iOS:
     - os: osx
       env: TARGET=i386-apple-ios
       name: "i386-apple-ios"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     - env: TARGET=aarch64-linux-android RUSTFLAGS="-C target-feature=+neon"
       name: "aarch64-unknown-linux-android + NEON"
     # Linux:
+    - env: TARGET=i586-unknown-linux-gnu
+      name: "i586-unknown-linux-gnu"
     - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse"
       name: "i586-unknown-linux-gnu + SSE"
     - env: TARGET=i586-unknown-linux-gnu RUSTFLAGS="-C target-feature=+sse2"

--- a/ci/run_examples.sh
+++ b/ci/run_examples.sh
@@ -8,7 +8,8 @@ fi
 
 # FIXME: travis exceeds 50 minutes on these targets
 # Skipping the examples is an attempt at preventing travis from timing-out
-if [[ ${TARGET} == "arm-linux-androidabi" ]] || [[ ${TARGET} == "aarch64-linux-androidabi" ]]; then
+if [[ ${TARGET} == "arm-linux-androidabi" ]] || [[ ${TARGET} == "aarch64-linux-androidabi" ]] \
+    || [[ ${TARGET} == "sparc64-unknown-linux-gnu" ]]; then
     exit 0
 fi
 

--- a/ci/run_examples.sh
+++ b/ci/run_examples.sh
@@ -45,3 +45,6 @@ if [[ ${TARGET} != "i586-unknown-linux-gnu" ]]; then
     cp -r examples/stencil target/stencil
     cargo_test --manifest-path=target/stencil/Cargo.toml --release
 fi
+
+cp -r examples/triangle_xform target/triangle_xform
+cargo_test --manifest-path=target/triangle_xform/Cargo.toml --release

--- a/examples/dot_product/src/lib.rs
+++ b/examples/dot_product/src/lib.rs
@@ -1,5 +1,6 @@
 //! Vector dot product
 #![deny(warnings)]
+#![feature(custom_inner_attributes)]
 
 extern crate packed_simd;
 

--- a/examples/matrix_inverse/src/lib.rs
+++ b/examples/matrix_inverse/src/lib.rs
@@ -1,4 +1,5 @@
 //! 4x4 matrix inverse
+#![feature(custom_inner_attributes)]
 #![deny(warnings)]
 
 #[macro_use(shuffle)]

--- a/examples/options_pricing/src/main.rs
+++ b/examples/options_pricing/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(custom_inner_attributes)]
+
 extern crate options_pricing_lib;
 use options_pricing_lib::*;
 

--- a/examples/stencil/src/lib.rs
+++ b/examples/stencil/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(stmt_expr_attributes)]
+#![feature(custom_inner_attributes, stmt_expr_attributes)]
 #![deny(warnings)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(

--- a/examples/stencil/src/main.rs
+++ b/examples/stencil/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(custom_inner_attributes)]
+
 extern crate stencil_lib;
 use stencil_lib::*;
 

--- a/examples/triangle_xform/Cargo.toml
+++ b/examples/triangle_xform/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "triangle_xform"
+version = "0.1.0"
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+packed_simd = { path = "../.." }
+
+[dev-dependencies]
+rand = "0.5.5"
+time = "0.1.40"

--- a/examples/triangle_xform/readme.md
+++ b/examples/triangle_xform/readme.md
@@ -1,0 +1,58 @@
+# Transforming triangle vertices using a transformation matrix
+
+## Description
+
+This example contains the SIMD implementation of a common computer graphics task:
+transforming vertices with a matrix.
+
+## Implementation
+
+There are two implementations:
+
+- scalar version, uses an array-of-structures layout, where each triangle contains
+  three vertices, and each vertex contains only a 3D position vector; the algorithm
+  operates on **one triangle at a time**.
+
+- SIMD version, uses a structure-of-arrays layout, where the structure contains, for
+  each of the X, Y, and Z components of a 3D vector, an array of their values; the
+  algorithm operates on **up to N triangles at once**, where N is number of lanes in a
+  SIMD register.
+
+To simplify the implementation, the transformation matrix is composed only of simple
+rotation, scaling and translation matrices.
+
+Both implementations are single-threaded. They can be easily parallelized using [rayon]
+and dividing the list of triangles into chunks.
+
+[rayon]: https://github.com/rayon-rs/rayon
+
+## Benchmark results
+
+This crate is mainly intended for educational purposes, since performance improvements
+will likely come from using the transformed triangles in SIMD layout further down the
+pipeline.
+
+In order to compare the generated results, the tests will convert the SIMD output back
+into a scalar representation.
+
+That being said, the crate's tests also come with a micro-benchmark.
+Run the unit tests in release mode, and with `stdout` capture disabled:
+
+```sh
+cargo test --release -- --no-capture
+```
+
+Benchmark results on an Intel i5 with AVX, for 2^24 triangles:
+
+| algorithm |  time  |
+|-----------|--------|
+|  scalar   | 255 ms |
+|  simd     | 237 ms |
+
+(**Note**: the benchmark does not take into account the time required for transforming
+the data into an SIMD layout)
+
+SIMD is a mere 7% faster than the scalar algorithm, since LLVM was already able to
+vectorize most of the multiplication code. Since we're not doing a lot of processing
+on the triangles after transforming them, this "benchmark" is very limited by memory
+bandwidth.

--- a/examples/triangle_xform/readme.md
+++ b/examples/triangle_xform/readme.md
@@ -36,6 +36,9 @@ In order to compare the generated results, the tests will convert the SIMD outpu
 into a scalar representation.
 
 That being said, the crate's tests also come with a micro-benchmark.
+It is recommended to increase the `TRIANGLE_COUNT` constant to the point where
+you get accurate benchmark results.
+
 Run the unit tests in release mode, and with `stdout` capture disabled:
 
 ```sh

--- a/examples/triangle_xform/src/lib.rs
+++ b/examples/triangle_xform/src/lib.rs
@@ -13,7 +13,7 @@ mod tests {
     use super::*;
     use rand::prelude::*;
 
-    const TRIANGLE_COUNT: usize = 1 << 20;
+    const TRIANGLE_COUNT: usize = 1 << 5;
 
     #[test]
     fn compare_scalar_simd() {
@@ -57,6 +57,12 @@ mod tests {
             .flat_map(|tri| tri.unpack())
             .collect::<Vec<_>>();
 
-        assert_eq!(scalar_xformed, simd_xformed);
+        if scalar_xformed != simd_xformed {
+            scalar_xformed.into_iter()
+                .zip(simd_xformed.into_iter())
+                .for_each(|(a, b)| {
+                    assert_eq!(a, b, "Triangles do not match");
+                });
+        }
     }
 }

--- a/examples/triangle_xform/src/lib.rs
+++ b/examples/triangle_xform/src/lib.rs
@@ -57,11 +57,19 @@ mod tests {
             .flat_map(|tri| tri.unpack())
             .collect::<Vec<_>>();
 
+        const EPSILON: f32 = 1E-5;
+
         if scalar_xformed != simd_xformed {
             scalar_xformed.into_iter()
                 .zip(simd_xformed.into_iter())
                 .for_each(|(a, b)| {
-                    assert_eq!(a, b, "Triangles do not match");
+                    if a != b {
+                        a.0.into_iter().zip(b.0.into_iter()).for_each(|(v1, v2)| {
+                            v1.into_iter().zip(v2.into_iter()).for_each(|(a, b)| {
+                                assert!((a - b).abs() <= EPSILON, "Vertex components do not match");
+                            });
+                        });
+                    }
                 });
         }
     }

--- a/examples/triangle_xform/src/scalar.rs
+++ b/examples/triangle_xform/src/scalar.rs
@@ -1,0 +1,75 @@
+use super::Matrix;
+
+/// Vertex data: a single 3D vector of floats, representing position.
+pub type Vertex = [f32; 3];
+
+/// Triangle type for array-of-structs layout.
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub struct Triangle(pub [Vertex; 3]);
+
+impl Triangle {
+    /// Transforms this triangle by multiplying with a matrix.
+    #[inline]
+    pub fn transform(self, mat: Matrix) -> Self {
+        let mut xformed: [Vertex; 3] = Default::default();
+
+        let vertices = self.0;
+
+        let col_a = mat[0];
+        let col_b = mat[1];
+        let col_c = mat[2];
+        let col_d = mat[3];
+
+        for k in 0..3 {
+            let v = vertices[k];
+
+            let x = col_a[0] * v[0] + col_b[0] * v[1] + col_c[0] * v[2] + col_d[0];
+            let y = col_a[1] * v[0] + col_b[1] * v[1] + col_c[1] * v[2] + col_d[1];
+            let z = col_a[2] * v[0] + col_b[2] * v[1] + col_c[2] * v[2] + col_d[2];
+
+            xformed[k] = [x, y, z];
+        }
+
+        Triangle(xformed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{distributions::Standard, prelude::*};
+
+    impl Distribution<Triangle> for Standard {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Triangle {
+            Triangle(self.sample(rng))
+        }
+    }
+
+    #[test]
+    fn translate() {
+        let tri = Triangle([
+            [-0.5, -0.5, 0.0],
+            [0.5, -0.5, 0.0],
+            [0.0, 0.5, 0.0],
+        ]);
+
+        let (x, y, z) = (-0.25, 0.5, 1.0);
+
+        let matrix = [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [x, y, z],
+        ];
+
+        let tri = tri.transform(matrix);
+
+        let expected = Triangle([
+            [-0.75, 0.0, 1.0],
+            [0.25, 0.0, 1.0],
+            [-0.25, 1.0, 1.0],
+        ]);
+
+        assert_eq!(tri, expected);
+    }
+}

--- a/examples/triangle_xform/src/simd.rs
+++ b/examples/triangle_xform/src/simd.rs
@@ -1,0 +1,85 @@
+use super::Matrix;
+
+/// SIMD vector of floats
+pub type VecF = packed_simd::f32x8;
+
+/// SIMD batch of N triangles, where N is SIMD width.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Triangle {
+    pub x: [VecF; 3],
+    pub y: [VecF; 3],
+    pub z: [VecF; 3],
+}
+
+impl Triangle {
+    /// Combines N scalar triangles into a single SIMD triangle.
+    pub fn pack(tris: &[crate::scalar::Triangle]) -> Self {
+        assert_eq!(tris.len(), VecF::lanes());
+
+        let mut x = [VecF::splat(0.0); 3];
+        let mut y = [VecF::splat(0.0); 3];
+        let mut z = [VecF::splat(0.0); 3];
+        for k in 0..3 {
+            let x = &mut x[k];
+            let y = &mut y[k];
+            let z = &mut z[k];
+
+            for i in 0..VecF::lanes() {
+                let t = tris[i];
+                let vertex = t.0[k];
+                let tx = vertex[0];
+                let ty = vertex[1];
+                let tz = vertex[2];
+
+                *x = x.replace(i, tx);
+                *y = y.replace(i, ty);
+                *z = z.replace(i, tz);
+            }
+        }
+
+        Triangle { x, y, z }
+    }
+
+    /// Unpacks the N scalar triangles into an array-of-structures layout.
+    pub fn unpack(self) -> Vec<crate::scalar::Triangle> {
+        let mut tris = [crate::scalar::Triangle::default(); VecF::lanes()];
+
+        for k in 0..3 {
+            for i in 0..VecF::lanes() {
+                let vtx = &mut tris[i].0;
+                vtx[k][0] = self.x[k].extract(i);
+                vtx[k][1] = self.y[k].extract(i);
+                vtx[k][2] = self.z[k].extract(i);
+            }
+        }
+
+        tris.to_vec()
+    }
+
+    /// Transforms this triangle by multiplying with a matrix.
+    #[inline]
+    pub fn transform(self, mat: Matrix) -> Self {
+        let mut tri = Triangle::default();
+
+        let x = self.x;
+        let y = self.y;
+        let z = self.z;
+
+        let col_a = mat[0];
+        let col_b = mat[1];
+        let col_c = mat[2];
+        let col_d = mat[3];
+
+        for k in 0..3 {
+            let x = x[k];
+            let y = y[k];
+            let z = z[k];
+
+            tri.x[k] = col_a[0] * x + col_b[0] * y + col_c[0] * z + col_d[0];
+            tri.y[k] = col_a[1] * x + col_b[1] * y + col_c[1] * z + col_d[1];
+            tri.z[k] = col_a[2] * x + col_b[2] * y + col_c[2] * z + col_d[2];
+        }
+
+        tri
+    }
+}

--- a/examples/triangle_xform/src/simd.rs
+++ b/examples/triangle_xform/src/simd.rs
@@ -19,12 +19,12 @@ impl Triangle {
         let mut x = [VecF::splat(0.0); 3];
         let mut y = [VecF::splat(0.0); 3];
         let mut z = [VecF::splat(0.0); 3];
-        for k in 0..3 {
+        (0..3).for_each(|k| {
             let x = &mut x[k];
             let y = &mut y[k];
             let z = &mut z[k];
 
-            for i in 0..VecF::lanes() {
+            (0..VecF::lanes()).for_each(|i| {
                 let t = tris[i];
                 let vertex = t.0[k];
                 let tx = vertex[0];
@@ -34,24 +34,24 @@ impl Triangle {
                 *x = x.replace(i, tx);
                 *y = y.replace(i, ty);
                 *z = z.replace(i, tz);
-            }
-        }
+            });
+        });
 
-        Triangle { x, y, z }
+        Self { x, y, z }
     }
 
     /// Unpacks the N scalar triangles into an array-of-structures layout.
     pub fn unpack(self) -> Vec<crate::scalar::Triangle> {
         let mut tris = [crate::scalar::Triangle::default(); VecF::lanes()];
 
-        for k in 0..3 {
-            for i in 0..VecF::lanes() {
+        (0..3).for_each(|k| {
+            (0..VecF::lanes()).for_each(|i| {
                 let vtx = &mut tris[i].0;
                 vtx[k][0] = self.x[k].extract(i);
                 vtx[k][1] = self.y[k].extract(i);
                 vtx[k][2] = self.z[k].extract(i);
-            }
-        }
+            });
+        });
 
         tris.to_vec()
     }
@@ -59,7 +59,7 @@ impl Triangle {
     /// Transforms this triangle by multiplying with a matrix.
     #[inline]
     pub fn transform(self, mat: Matrix) -> Self {
-        let mut tri = Triangle::default();
+        let mut tri = Self::default();
 
         let x = self.x;
         let y = self.y;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,8 @@
     stmt_expr_attributes,
     align_offset,
     mmx_target_feature,
-    crate_visibility_modifier
+    crate_visibility_modifier,
+    custom_inner_attributes,
 )]
 #![allow(non_camel_case_types, non_snake_case)]
 #![cfg_attr(test, feature(plugin, hashmap_internals))]


### PR DESCRIPTION
I wanted to create a simple example which shows how code using triangles (such as those encountered in computer graphics) can be SIMDified.

`aobench` does have a `VecxN` class which gives an idea on how to operate on 3D vectors by breaking them in their components, but this example is much smaller and easier to understand.

I also fixed an issue with the latest nightly.