### PR TITLE
Update all crates to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-lang-nursery/packed_simd"
 keywords = ["simd", "vector", "portability"]
 categories = ["hardware-support", "concurrency", "no-std", "data-structures"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [badges]
 appveyor = { repository = "rust-lang-nursery/packed_simd" }

--- a/examples/aobench/Cargo.toml
+++ b/examples/aobench/Cargo.toml
@@ -3,6 +3,7 @@ name = "aobench"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 autobenches = false
+edition = "2018"
 
 [[bin]]
 name = "aobench"

--- a/examples/aobench/benches/ambient_occlusion.rs
+++ b/examples/aobench/benches/ambient_occlusion.rs
@@ -1,11 +1,6 @@
 //! Benchmarks intersection between rays and planes
 #![feature(stdsimd)]
 
-extern crate aobench_lib;
-
-#[macro_use]
-extern crate criterion;
-
 use aobench_lib::*;
 use criterion::*;
 use intersection::Isect;
@@ -17,7 +12,7 @@ fn hit_scalar(c: &mut Criterion) {
         "scalar",
         Benchmark::new("ao_hit", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut scene);
                 let mut v = ambient_occlusion::scalar(s, isect);
@@ -34,7 +29,7 @@ fn hit_vector(c: &mut Criterion) {
         "vector",
         Benchmark::new("ao_hit", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut scene);
                 let mut v = ambient_occlusion::vector(s, isect);

--- a/examples/aobench/benches/isec_plane.rs
+++ b/examples/aobench/benches/isec_plane.rs
@@ -1,16 +1,11 @@
 //! Benchmarks intersection between rays and planes
 #![feature(stdsimd)]
 
-extern crate aobench_lib;
-
-#[macro_use]
-extern crate criterion;
-
 use criterion::*;
 
 use aobench_lib::*;
-use geometry::{f32xN, Plane, Ray, RayxN, V3DxN, V3D};
-use intersection::{Intersect, Isect, IsectxN};
+use crate::geometry::{f32xN, Plane, Ray, RayxN, V3DxN, V3D};
+use crate::intersection::{Intersect, Isect, IsectxN};
 
 fn hit_scalar(c: &mut Criterion) {
     let mut s = Plane {
@@ -42,7 +37,7 @@ fn hit_scalar(c: &mut Criterion) {
         "scalar",
         Benchmark::new("isec_plane_hit", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -84,7 +79,7 @@ fn miss_scalar(c: &mut Criterion) {
         "scalar",
         Benchmark::new("isec_plane_miss", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -126,7 +121,7 @@ fn hit_vector(c: &mut Criterion) {
         "vector",
         Benchmark::new("isec_plane_hit", move |b| {
             b.iter(|| {
-                let mut isect = IsectxN::new();
+                let mut isect = IsectxN::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -168,7 +163,7 @@ fn miss_vector(c: &mut Criterion) {
         "vector",
         Benchmark::new("isec_plane_miss", move |b| {
             b.iter(|| {
-                let mut isect = IsectxN::new();
+                let mut isect = IsectxN::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);

--- a/examples/aobench/benches/isec_sphere.rs
+++ b/examples/aobench/benches/isec_sphere.rs
@@ -1,15 +1,11 @@
 //! Benchmarks intersection between rays and spheres
 #![feature(stdsimd)]
 
-extern crate aobench_lib;
-
-#[macro_use]
-extern crate criterion;
-
+use test::*;
 use aobench_lib::*;
 use criterion::*;
-use geometry::{f32xN, Ray, RayxN, Sphere, V3DxN, V3D};
-use intersection::{Intersect, Isect, IsectxN};
+use crate::geometry::{f32xN, Ray, RayxN, Sphere, V3DxN, V3D};
+use crate::intersection::{Intersect, Isect, IsectxN};
 
 fn hit_scalar(c: &mut Criterion) {
     let mut s = Sphere {
@@ -38,7 +34,7 @@ fn hit_scalar(c: &mut Criterion) {
         "scalar",
         Benchmark::new("isec_sphere_hit", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -76,7 +72,7 @@ fn miss_scalar(c: &mut Criterion) {
         "scalar",
         Benchmark::new("isec_sphere_miss", move |b| {
             b.iter(|| {
-                let mut isect = Isect::new();
+                let mut isect = Isect::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -114,7 +110,7 @@ fn hit_vector(c: &mut Criterion) {
         "vector",
         Benchmark::new("isec_sphere_hit", move |b| {
             b.iter(|| {
-                let mut isect = IsectxN::new();
+                let mut isect = IsectxN::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);
@@ -152,7 +148,7 @@ fn miss_vector(c: &mut Criterion) {
         "vector",
         Benchmark::new("isec_sphere_miss", move |b| {
             b.iter(|| {
-                let mut isect = IsectxN::new();
+                let mut isect = IsectxN::default();
                 let isect = black_box(&mut isect);
                 let s = black_box(&mut s);
                 let r = black_box(&mut r);

--- a/examples/aobench/benches/random.rs
+++ b/examples/aobench/benches/random.rs
@@ -1,11 +1,6 @@
 //! Benchmarks PNRG
 #![feature(stdsimd)]
 
-extern crate aobench_lib;
-
-#[macro_use]
-extern crate criterion;
-
 use aobench_lib::geometry::f32xN;
 use aobench_lib::random;
 use criterion::*;

--- a/examples/aobench/benches/scanlines.rs
+++ b/examples/aobench/benches/scanlines.rs
@@ -1,8 +1,5 @@
 #![feature(test)]
 
-extern crate aobench_lib;
-
-extern crate test;
 use test::{black_box, Bencher};
 
 #[bench]

--- a/examples/aobench/build.rs
+++ b/examples/aobench/build.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "ispc")]
-extern crate ispc;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/examples/aobench/src/ambient_occlusion.rs
+++ b/examples/aobench/src/ambient_occlusion.rs
@@ -1,8 +1,8 @@
 //! Ambient Occlusion implementations
 
-use geometry::{f32xN, Ray, RayxN, Selectable, V3DxN, V3D};
-use intersection::{Intersect, Isect, IsectxN};
-use scene::Scene;
+use crate::geometry::{f32xN, Ray, RayxN, Selectable, V3DxN, V3D};
+use crate::intersection::{Intersect, Isect, IsectxN};
+use crate::scene::Scene;
 use std::f32::consts::PI;
 
 /// Scalar ambient occlusion algorithm
@@ -128,11 +128,11 @@ pub fn vector_tiled<S: Scene>(scene: &mut S, isect: &IsectxN) -> f32xN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geometry::V3D;
+    use crate::geometry::V3D;
 
     #[test]
     fn sanity_hit() {
-        let scene = ::scene::Test::default();
+        let scene = crate::scene::Test::default();
         let mut scene_scalar = scene.clone();
         let mut scene_vector = scene.clone();
         let ray = Ray {
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn sanity_miss() {
-        let scene = ::scene::Test::default();
+        let scene = crate::scene::Test::default();
         let mut scene_scalar = scene.clone();
         let mut scene_vector = scene.clone();
 

--- a/examples/aobench/src/geometry/plane.rs
+++ b/examples/aobench/src/geometry/plane.rs
@@ -1,6 +1,6 @@
 //! Plane
 
-use geometry::V3D;
+use crate::geometry::V3D;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Plane {

--- a/examples/aobench/src/geometry/ray.rs
+++ b/examples/aobench/src/geometry/ray.rs
@@ -1,6 +1,6 @@
 //! A ray
 
-use geometry::V3D;
+use crate::geometry::V3D;
 
 /// Ray starting at `origin` in `dir` direction.
 #[derive(Copy, Clone, Debug)]

--- a/examples/aobench/src/geometry/rayxN.rs
+++ b/examples/aobench/src/geometry/rayxN.rs
@@ -1,6 +1,6 @@
 //! Four packed rays
 
-use geometry::{Ray, V3DxN};
+use crate::geometry::{Ray, V3DxN};
 
 /// Four packed rays starting at `origin` in `dir` direction.
 #[derive(Copy, Clone, Debug)]

--- a/examples/aobench/src/geometry/sphere.rs
+++ b/examples/aobench/src/geometry/sphere.rs
@@ -1,6 +1,6 @@
 //! Sphere
 
-use geometry::V3D;
+use crate::geometry::V3D;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Sphere {

--- a/examples/aobench/src/geometry/vec.rs
+++ b/examples/aobench/src/geometry/vec.rs
@@ -153,7 +153,7 @@ impl Mul<V3D> for M3x3 {
 /// Vector dot product
 pub trait Dot<O> {
     type Output;
-    fn dot(self, O) -> Self::Output;
+    fn dot(self, _: O) -> Self::Output;
 }
 
 impl Dot<V3D> for V3D {

--- a/examples/aobench/src/geometry/vecxN.rs
+++ b/examples/aobench/src/geometry/vecxN.rs
@@ -2,7 +2,7 @@
 
 use std::ops::*;
 
-use geometry::{f32xN, m32xN, Dot, M3x3, V3D};
+use crate::geometry::{f32xN, m32xN, Dot, M3x3, V3D};
 
 #[derive(Copy, Clone, Debug)]
 pub struct V3DxN {

--- a/examples/aobench/src/intersection/packet.rs
+++ b/examples/aobench/src/intersection/packet.rs
@@ -1,7 +1,7 @@
 //! SIMD intersection result
 
-use geometry::{f32xN, m32xN, V3DxN};
-use intersection::Isect;
+use crate::geometry::{f32xN, m32xN, V3DxN};
+use crate::intersection::Isect;
 
 /// Intersection result
 #[derive(Copy, Clone, Debug)]

--- a/examples/aobench/src/intersection/ray_plane.rs
+++ b/examples/aobench/src/intersection/ray_plane.rs
@@ -1,7 +1,7 @@
 //! Intersection of a ray with a plane
 
-use geometry::{f32xN, Dot, Plane, Ray, RayxN, Selectable};
-use intersection::{Intersect, Isect, IsectxN};
+use crate::geometry::{f32xN, Dot, Plane, Ray, RayxN, Selectable};
+use crate::intersection::{Intersect, Isect, IsectxN};
 
 // Scalar ray-plane intersection
 impl Intersect<Plane> for Ray {
@@ -72,7 +72,7 @@ impl Intersect<Plane> for RayxN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geometry::{m32xN, V3DxN, V3D};
+    use crate::geometry::{m32xN, V3DxN, V3D};
 
     #[test]
     fn sanity() {

--- a/examples/aobench/src/intersection/ray_sphere.rs
+++ b/examples/aobench/src/intersection/ray_sphere.rs
@@ -1,7 +1,7 @@
 //! Intersection of a ray with a sphere.
 
-use geometry::{f32xN, Dot, Ray, RayxN, Selectable, Sphere};
-use intersection::{Intersect, Isect, IsectxN};
+use crate::geometry::{f32xN, Dot, Ray, RayxN, Selectable, Sphere};
+use crate::intersection::{Intersect, Isect, IsectxN};
 
 // Scalar ray-sphere intersection
 impl Intersect<Sphere> for Ray {
@@ -78,7 +78,7 @@ impl Intersect<Sphere> for RayxN {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geometry::{m32xN, V3DxN, V3D};
+    use crate::geometry::{m32xN, V3DxN, V3D};
 
     #[test]
     fn sanity() {

--- a/examples/aobench/src/intersection/single.rs
+++ b/examples/aobench/src/intersection/single.rs
@@ -1,6 +1,6 @@
 //! Scalar intersection result
 
-use geometry::V3D;
+use crate::geometry::V3D;
 
 /// Intersection result
 #[derive(Copy, Clone, Debug)]

--- a/examples/aobench/src/ispc_.rs
+++ b/examples/aobench/src/ispc_.rs
@@ -1,9 +1,9 @@
 //! Includes the ISPC implementations.
-use *;
+use crate::*;
 
 ispc_module!(aobench);
 
-pub fn ao<S: Scene>(_scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+pub fn ao<S: Scene>(_scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     unsafe {
         aobench::ao_ispc(
@@ -18,7 +18,7 @@ pub fn ao<S: Scene>(_scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
 pub fn ao_tasks<S: Scene>(
     _scene: &mut S,
     nsubsamples: usize,
-    img: &mut ::Image,
+    img: &mut crate::Image,
 ) {
     let (w, h) = img.size();
     unsafe {

--- a/examples/aobench/src/ispc_.rs
+++ b/examples/aobench/src/ispc_.rs
@@ -1,4 +1,5 @@
 //! Includes the ISPC implementations.
+use ispc::*;
 use crate::*;
 
 ispc_module!(aobench);
@@ -6,7 +7,7 @@ ispc_module!(aobench);
 pub fn ao<S: Scene>(_scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     unsafe {
-        aobench::ao_ispc(
+        self::aobench::ao_ispc(
             w as i32,
             h as i32,
             nsubsamples as i32,
@@ -22,7 +23,7 @@ pub fn ao_tasks<S: Scene>(
 ) {
     let (w, h) = img.size();
     unsafe {
-        aobench::ao_ispc_tasks(
+        self::aobench::ao_ispc_tasks(
             w as i32,
             h as i32,
             nsubsamples as i32,

--- a/examples/aobench/src/lib.rs
+++ b/examples/aobench/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Based on [aobench](https://code.google.com/archive/p/aobench/) by Syoyo
 //! Fujita.
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![allow(non_snake_case, non_camel_case_types)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
@@ -18,16 +18,6 @@
         clippy::erasing_op
     )
 )]
-
-#[macro_use]
-extern crate cfg_if;
-extern crate failure;
-extern crate packed_simd;
-extern crate png;
-extern crate rayon;
-#[cfg(feature = "ispc")]
-#[macro_use]
-extern crate ispc;
 
 pub mod ambient_occlusion;
 pub mod geometry;

--- a/examples/aobench/src/main.rs
+++ b/examples/aobench/src/main.rs
@@ -2,11 +2,7 @@
 //!
 //! Based on [aobench](https://code.google.com/archive/p/aobench/) by Syoyo
 //! Fujita.
-#![deny(warnings)]
-
-extern crate aobench_lib;
-extern crate structopt;
-extern crate time;
+#![deny(warnings, rust_2018_idioms)]
 
 use aobench_lib::*;
 use std::path::PathBuf;

--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -109,7 +109,7 @@ pub mod vector {
             let mut v = self.gen_u32();
             v &= u32xN::splat((1_u32 << 23) - 1);
             let v: f32xN = unsafe {
-                ::std::mem::transmute(u32xN::splat(0x3F80_0000) | v)
+                std::mem::transmute(u32xN::splat(0x3F80_0000) | v)
             };
             v - f32xN::splat(1.)
         }

--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -74,7 +74,7 @@ pub mod scalar {
 
 /// Vector pseudo random number generator
 pub mod vector {
-    use geometry::{f32xN, u32xN, IncrV};
+    use crate::geometry::{f32xN, u32xN, IncrV};
     use std::cell::UnsafeCell;
     use std::rc::Rc;
     struct RngT(u32xN, u32xN, u32xN, u32xN);

--- a/examples/aobench/src/scalar.rs
+++ b/examples/aobench/src/scalar.rs
@@ -1,11 +1,11 @@
 //! Scalar serial aobench
 
-use ambient_occlusion;
-use geometry::{Ray, V3D};
-use intersection::{Intersect, Isect};
-use scene::Scene;
+use crate::ambient_occlusion;
+use crate::geometry::{Ray, V3D};
+use crate::intersection::{Intersect, Isect};
+use crate::scene::Scene;
 
-pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     let image = &mut img.fdata;
     let ns = nsubsamples;

--- a/examples/aobench/src/scalar_parallel.rs
+++ b/examples/aobench/src/scalar_parallel.rs
@@ -1,12 +1,12 @@
 //! Scalar parallel aobench
 
-use ambient_occlusion;
-use geometry::{Ray, V3D};
-use intersection::{Intersect, Isect};
+use crate::ambient_occlusion;
+use crate::geometry::{Ray, V3D};
+use crate::intersection::{Intersect, Isect};
 use rayon::prelude::*;
-use scene::Scene;
+use crate::scene::Scene;
 
-pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
+pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     let ns = nsubsamples;
     img.fdata

--- a/examples/aobench/src/scene/mod.rs
+++ b/examples/aobench/src/scene/mod.rs
@@ -1,5 +1,5 @@
 /// Scene interface
-use geometry::{f32xN, Plane, Sphere};
+use crate::geometry::{f32xN, Plane, Sphere};
 
 pub trait Scene: Send + Sync + Default {
     const NAO_SAMPLES: usize;

--- a/examples/aobench/src/scene/random.rs
+++ b/examples/aobench/src/scene/random.rs
@@ -1,7 +1,7 @@
 //! Aobench scene: 3 spheres and a plane using a random number generator
 
-use geometry::{f32xN, Plane, Sphere, V3D};
-use scene::Scene;
+use crate::geometry::{f32xN, Plane, Sphere, V3D};
+use crate::scene::Scene;
 
 #[derive(Clone)]
 pub struct Random {
@@ -57,7 +57,7 @@ impl Scene for Random {
     const NAO_SAMPLES: usize = 8;
     #[inline(always)]
     fn rand(&mut self) -> f32 {
-        ::random::scalar::thread_rng().gen()
+        crate::random::scalar::thread_rng().gen()
     }
     #[inline(always)]
     fn plane(&self) -> &Plane {
@@ -69,7 +69,7 @@ impl Scene for Random {
     }
     #[inline(always)]
     fn rand_f32xN(&mut self) -> (f32xN, f32xN) {
-        let mut rng = ::random::vector::thread_rng();
+        let mut rng = crate::random::vector::thread_rng();
         (rng.gen(), rng.gen())
     }
 }

--- a/examples/aobench/src/scene/test.rs
+++ b/examples/aobench/src/scene/test.rs
@@ -1,7 +1,7 @@
 //! Aobench scene: 3 spheres and a plane using a random number generator
 
-use geometry::{Plane, Sphere, V3D};
-use scene::Scene;
+use crate::geometry::{Plane, Sphere, V3D};
+use crate::scene::Scene;
 use std::num::Wrapping;
 
 #[derive(Clone)]
@@ -53,7 +53,7 @@ impl Default for Test {
             },
         ];
         let mut rands = Vec::new();
-        let mut rng = ::random::scalar::thread_rng();
+        let mut rng = crate::random::scalar::thread_rng();
         for _ in 0..2 * Self::NAO_SAMPLES * Self::NAO_SAMPLES {
             rands.push(rng.gen());
         }

--- a/examples/aobench/src/tiled.rs
+++ b/examples/aobench/src/tiled.rs
@@ -1,12 +1,13 @@
 //! SIMD serial aobench
 
-use ambient_occlusion;
-use geometry::{f32xN, pf32xN, usizexN, IncrV, RayxN, V3DxN};
-use intersection::{Intersect, IsectxN};
-use scene::Scene;
+use crate::ambient_occlusion;
+use crate::geometry::{f32xN, pf32xN, usizexN, IncrV, RayxN, V3DxN};
+use crate::intersection::{Intersect, IsectxN};
+use crate::scene::Scene;
+use cfg_if::cfg_if;
 
 #[inline(always)]
-fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     assert_eq!(w % f32xN::lanes(), 0);
     let image = &mut img.fdata;
@@ -76,30 +77,30 @@ cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[target_feature(enable = "sse4.2")]
         unsafe fn ao_sse42<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                     img: &mut ::Image) {
+                                     img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx")]
         unsafe fn ao_avx<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                   img: &mut ::Image) {
+                                   img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx,fma")]
         unsafe fn ao_avx_fma<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                   img: &mut ::Image) {
+                                   img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx2,fma")]
         unsafe fn ao_avx2<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                    img: &mut ::Image) {
+                                    img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize,
-                            img: &mut ::Image) {
+                            img: &mut crate::Image) {
             unsafe {
                 if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
                     ao_avx2(scene, nsubsamples, img);

--- a/examples/aobench/src/tiled.rs
+++ b/examples/aobench/src/tiled.rs
@@ -118,7 +118,7 @@ cfg_if! {
             }
         }
     } else {
-        pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+        pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
     }

--- a/examples/aobench/src/tiled_parallel.rs
+++ b/examples/aobench/src/tiled_parallel.rs
@@ -1,12 +1,12 @@
 //! SIMD tiled parallel aobench
 
-use ambient_occlusion;
-use geometry::{f32xN, pf32xN, usizexN, IncrV, RayxN, V3DxN};
-use intersection::{Intersect, IsectxN};
+use crate::ambient_occlusion;
+use crate::geometry::{f32xN, pf32xN, usizexN, IncrV, RayxN, V3DxN};
+use crate::intersection::{Intersect, IsectxN};
 use rayon::prelude::*;
-use scene::Scene;
+use crate::scene::Scene;
 
-pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
+pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     assert_eq!(w % f32xN::lanes(), 0);
     let ns = nsubsamples;

--- a/examples/aobench/src/tiled_parallel.rs
+++ b/examples/aobench/src/tiled_parallel.rs
@@ -19,7 +19,7 @@ pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut crate::Image) {
             assert!(image.len() == 3 * w);
             let mut scene = S::default();
             let yf = f32xN::splat(y as f32);
-            let ptr: pf32xN = unsafe { ::std::mem::transmute(ptr) };
+            let ptr: pf32xN = unsafe { std::mem::transmute(ptr) };
             for x in (0..w).step_by(f32xN::lanes()) {
                 let xf = f32xN::incr(x as f32, 1.);
                 let offset = usizexN::splat(3 * (y * w + x));

--- a/examples/aobench/src/vector.rs
+++ b/examples/aobench/src/vector.rs
@@ -104,7 +104,7 @@ cfg_if! {
             }
         }
     } else {
-        pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+        pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
     }

--- a/examples/aobench/src/vector.rs
+++ b/examples/aobench/src/vector.rs
@@ -1,12 +1,13 @@
 //! SIMD serial aobench
 
-use ambient_occlusion;
-use geometry::{Ray, V3D};
-use intersection::{Intersect, Isect};
-use scene::Scene;
+use crate::ambient_occlusion;
+use crate::geometry::{Ray, V3D};
+use crate::intersection::{Intersect, Isect};
+use crate::scene::Scene;
+use cfg_if::cfg_if;
 
 #[inline(always)]
-fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut ::Image) {
+fn ao_impl<S: Scene>(scene: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     let image = &mut img.fdata;
     let ns = nsubsamples;
@@ -62,30 +63,30 @@ cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         #[target_feature(enable = "sse4.2")]
         unsafe fn ao_sse42<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                     img: &mut ::Image) {
+                                     img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx")]
         unsafe fn ao_avx<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                   img: &mut ::Image) {
+                                   img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx,fma")]
         unsafe fn ao_avx_fma<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                   img: &mut ::Image) {
+                                   img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         #[target_feature(enable = "avx2,fma")]
         unsafe fn ao_avx2<S: Scene>(scene: &mut S, nsubsamples: usize,
-                                    img: &mut ::Image) {
+                                    img: &mut crate::Image) {
             ao_impl(scene, nsubsamples, img);
         }
 
         pub fn ao<S: Scene>(scene: &mut S, nsubsamples: usize,
-                            img: &mut ::Image) {
+                            img: &mut crate::Image) {
             unsafe {
                 if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
                     ao_avx2(scene, nsubsamples, img);

--- a/examples/aobench/src/vector_parallel.rs
+++ b/examples/aobench/src/vector_parallel.rs
@@ -1,12 +1,12 @@
 //! SIMD parallel aobench
 
-use ambient_occlusion;
-use geometry::{Ray, V3D};
-use intersection::{Intersect, Isect};
+use crate::ambient_occlusion;
+use crate::geometry::{Ray, V3D};
+use crate::intersection::{Intersect, Isect};
 use rayon::prelude::*;
-use scene::Scene;
+use crate::scene::Scene;
 
-pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut ::Image) {
+pub fn ao<S: Scene>(_: &mut S, nsubsamples: usize, img: &mut crate::Image) {
     let (w, h) = img.size();
     let ns = nsubsamples;
     let inv_ns = 1. / (ns as f32);

--- a/examples/dot_product/Cargo.toml
+++ b/examples/dot_product/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dot_product"
 version = "0.1.0"
 authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/dot_product/src/lib.rs
+++ b/examples/dot_product/src/lib.rs
@@ -1,8 +1,6 @@
 //! Vector dot product
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![feature(custom_inner_attributes)]
-
-extern crate packed_simd;
 
 pub mod scalar;
 pub mod simd;

--- a/examples/dot_product/src/scalar.rs
+++ b/examples/dot_product/src/scalar.rs
@@ -8,5 +8,5 @@ pub fn dot_prod(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(test)]
 #[test]
 fn test() {
-    ::test(dot_prod)
+    crate::test(dot_prod)
 }

--- a/examples/dot_product/src/simd.rs
+++ b/examples/dot_product/src/simd.rs
@@ -19,5 +19,5 @@ pub fn dot_prod(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(test)]
 #[test]
 fn test() {
-    ::test(dot_prod)
+    crate::test(dot_prod)
 }

--- a/examples/fannkuch_redux/Cargo.toml
+++ b/examples/fannkuch_redux/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fannkuch_redux"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/fannkuch_redux/src/lib.rs
+++ b/examples/fannkuch_redux/src/lib.rs
@@ -1,5 +1,5 @@
 //! Fannkuch redux
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![allow(non_snake_case, non_camel_case_types)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
@@ -12,7 +12,6 @@
         clippy::cast_possible_wrap
     )
 )]
-extern crate packed_simd;
 
 pub mod scalar;
 pub mod simd;

--- a/examples/fannkuch_redux/src/main.rs
+++ b/examples/fannkuch_redux/src/main.rs
@@ -1,6 +1,5 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 
-extern crate fannkuch_redux_lib;
 use fannkuch_redux_lib::*;
 
 fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {

--- a/examples/fannkuch_redux/src/main.rs
+++ b/examples/fannkuch_redux/src/main.rs
@@ -2,7 +2,7 @@
 
 use fannkuch_redux_lib::*;
 
-fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
+fn run<O: std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let (checksum, maxflips) = fannkuch_redux(n, alg);
     writeln!(o, "{}\nPfannkuchen({}) = {}", checksum, n, maxflips).unwrap();
 }
@@ -17,7 +17,7 @@ fn main() {
         0
     };
 
-    run(&mut ::std::io::stdout(), n, alg);
+    run(&mut std::io::stdout(), n, alg);
 }
 
 #[cfg(test)]

--- a/examples/fannkuch_redux/src/simd.rs
+++ b/examples/fannkuch_redux/src/simd.rs
@@ -1,7 +1,6 @@
 //! Vectorized fannkuch redux implementation
 
 use packed_simd::*;
-use *;
 
 struct State {
     s: [u8; 16],

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -3,6 +3,7 @@ name = "mandelbrot"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/mandelbrot/build.rs
+++ b/examples/mandelbrot/build.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "ispc")]
-extern crate ispc;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/examples/mandelbrot/src/ispc_tasks.rs
+++ b/examples/mandelbrot/src/ispc_tasks.rs
@@ -1,5 +1,6 @@
 //! Includes the ISPC implementations.
-use *;
+use crate::*;
+use ispc::*;
 
 ispc_module!(mandelbrot);
 

--- a/examples/mandelbrot/src/lib.rs
+++ b/examples/mandelbrot/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/mandelbrot.html#mandelbrot
 
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -12,12 +12,6 @@
         clippy::cast_possible_truncation
     )
 )]
-
-extern crate packed_simd;
-extern crate rayon;
-#[cfg(feature = "ispc")]
-#[macro_use]
-extern crate ispc;
 
 use rayon::prelude::*;
 use std::{io, ops};
@@ -87,7 +81,7 @@ impl Mandelbrot {
     }
 
     /// Writes the PBM / PPM header to the output.
-    fn write_header(&self, f: &mut io::Write, color: bool) -> io::Result<()> {
+    fn write_header(&self, f: &mut dyn io::Write, color: bool) -> io::Result<()> {
         writeln!(f, "P{}", if color { 6 } else { 4 })?;
         write!(f, "{} {}", self.dims.0, self.dims.1)?;
         if color {
@@ -97,7 +91,7 @@ impl Mandelbrot {
     }
 
     /// Outputs a black/white PBM bitmap to the given writer.
-    pub fn output_pbm(&self, f: &mut io::Write) -> io::Result<()> {
+    pub fn output_pbm(&self, f: &mut dyn io::Write) -> io::Result<()> {
         self.write_header(f, false)?;
 
         assert_eq!(
@@ -121,7 +115,7 @@ impl Mandelbrot {
     }
 
     /// Outputs a color PPM image to the given writer.
-    pub fn output_ppm(&self, f: &mut io::Write) -> io::Result<()> {
+    pub fn output_ppm(&self, f: &mut dyn io::Write) -> io::Result<()> {
         self.write_header(f, true)?;
 
         let buf = self

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -2,11 +2,9 @@
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/mandelbrot.html#mandelbrot
 
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 
-extern crate mandelbrot_lib;
-extern crate structopt;
 use mandelbrot_lib::*;
 use std::io;
 use structopt::StructOpt;

--- a/examples/mandelbrot/src/scalar_par.rs
+++ b/examples/mandelbrot/src/scalar_par.rs
@@ -1,7 +1,7 @@
 //! Scalar mandelbrot implementation
 
 use rayon::prelude::*;
-use *;
+use crate::*;
 
 /// Complex number
 #[repr(align(16))]

--- a/examples/mandelbrot/src/simd_par.rs
+++ b/examples/mandelbrot/src/simd_par.rs
@@ -3,7 +3,7 @@
 
 use packed_simd::*;
 use rayon::prelude::*;
-use *;
+use crate::*;
 
 type u64s = u64x8;
 type u32s = u32x8;

--- a/examples/matrix_inverse/Cargo.toml
+++ b/examples/matrix_inverse/Cargo.toml
@@ -2,6 +2,7 @@
 name = "matrix_inverse"
 version = "0.1.0"
 authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/matrix_inverse/src/lib.rs
+++ b/examples/matrix_inverse/src/lib.rs
@@ -1,9 +1,6 @@
 //! 4x4 matrix inverse
 #![feature(custom_inner_attributes)]
-#![deny(warnings)]
-
-#[macro_use(shuffle)]
-extern crate packed_simd;
+#![deny(warnings, rust_2018_idioms)]
 
 pub mod scalar;
 pub mod simd;

--- a/examples/matrix_inverse/src/scalar.rs
+++ b/examples/matrix_inverse/src/scalar.rs
@@ -1,6 +1,6 @@
 //! Scalar implementation
 #![rustfmt::skip]
-use ::*;
+use crate::*;
 
 pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
     let m = m.0;

--- a/examples/matrix_inverse/src/scalar.rs
+++ b/examples/matrix_inverse/src/scalar.rs
@@ -146,5 +146,5 @@ pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
 #[cfg(test)]
 #[test]
 fn test() {
-    ::test(inv4x4)
+    crate::test(inv4x4)
 }

--- a/examples/matrix_inverse/src/simd.rs
+++ b/examples/matrix_inverse/src/simd.rs
@@ -1,5 +1,6 @@
 //! 4x4 matrix inverse using SIMD
-use *;
+use crate::*;
+use packed_simd::shuffle;
 
 use packed_simd::f32x4;
 

--- a/examples/matrix_inverse/src/simd.rs
+++ b/examples/matrix_inverse/src/simd.rs
@@ -104,5 +104,5 @@ pub fn inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
 #[cfg(test)]
 #[test]
 fn test() {
-    ::test(inv4x4)
+    crate::test(inv4x4)
 }

--- a/examples/nbody/Cargo.toml
+++ b/examples/nbody/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nbody"
 version = "0.1.0"
 authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/nbody/src/lib.rs
+++ b/examples/nbody/src/lib.rs
@@ -1,13 +1,12 @@
 //! The N-body benchmark from the [benchmarks game][bg].
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(clippy::similar_names, clippy::excessive_precision)
 )]
-extern crate packed_simd;
 
 pub mod scalar;
 pub mod simd;

--- a/examples/nbody/src/main.rs
+++ b/examples/nbody/src/main.rs
@@ -3,7 +3,7 @@
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody
 #![deny(warnings, rust_2018_idioms)]
 
-fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
+fn run<O: std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let (energy_before, energy_after) = nbody_lib::run(n, alg);
 
     writeln!(o, "{:.9}", energy_before);
@@ -23,7 +23,7 @@ fn main() {
         1 // SIMD algorithm
     };
 
-    run(&mut ::std::io::stdout(), n, alg);
+    run(&mut std::io::stdout(), n, alg);
 }
 
 #[cfg(test)]

--- a/examples/nbody/src/main.rs
+++ b/examples/nbody/src/main.rs
@@ -1,8 +1,7 @@
 //! The N-body benchmark from the [benchmarks game][bg].
 //!
 //! [bg]: https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody
-#![deny(warnings)]
-extern crate nbody_lib;
+#![deny(warnings, rust_2018_idioms)]
 
 fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let (energy_before, energy_after) = nbody_lib::run(n, alg);

--- a/examples/nbody/src/scalar.rs
+++ b/examples/nbody/src/scalar.rs
@@ -150,7 +150,7 @@ fn shift_mut_ref<'a, T>(r: &mut &'a mut [T]) -> Option<&'a mut T> {
     if r.is_empty() {
         return None;
     }
-    let tmp = ::std::mem::replace(r, &mut []);
+    let tmp = std::mem::replace(r, &mut []);
     let (h, t) = tmp.split_at_mut(1);
     *r = t;
     Some(&mut h[0])
@@ -171,7 +171,7 @@ pub fn run(n: usize) -> (f64, f64) {
 mod tests {
     #[test]
     fn test() {
-        for &(size, a_e, b_e) in ::RESULTS {
+        for &(size, a_e, b_e) in crate::RESULTS {
             let (a, b) = super::run(size);
             assert_eq!(format!("{:.9}", a), a_e);
             assert_eq!(format!("{:.9}", b), b_e);

--- a/examples/nbody/src/simd.rs
+++ b/examples/nbody/src/simd.rs
@@ -169,7 +169,7 @@ pub fn run(n: usize) -> (f64, f64) {
 mod tests {
     #[test]
     fn test() {
-        for &(size, a_e, b_e) in ::RESULTS {
+        for &(size, a_e, b_e) in crate::RESULTS {
             let (a, b) = super::run(size);
             assert_eq!(format!("{:.9}", a), a_e);
             assert_eq!(format!("{:.9}", b), b_e);

--- a/examples/options_pricing/Cargo.toml
+++ b/examples/options_pricing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "options_pricing"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/options_pricing/build.rs
+++ b/examples/options_pricing/build.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "ispc")]
-extern crate ispc;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/examples/options_pricing/src/ispc_.rs
+++ b/examples/options_pricing/src/ispc_.rs
@@ -1,5 +1,6 @@
 //! Includes the ISPC implementations.
 
+use ispc::*;
 ispc_module!(options);
 
 pub mod black_scholes {
@@ -10,7 +11,7 @@ pub mod black_scholes {
         result: &mut [f32], count: usize,
     ) -> f64 {
         unsafe {
-            options::black_scholes_ispc(
+            self::options::black_scholes_ispc(
                 sa.as_ptr() as *mut f32,
                 xa.as_ptr() as *mut f32,
                 ta.as_ptr() as *mut f32,
@@ -27,7 +28,7 @@ pub mod black_scholes {
         result: &mut [f32], count: usize,
     ) -> f64 {
         unsafe {
-            options::black_scholes_ispc_tasks(
+            self::options::black_scholes_ispc_tasks(
                 sa.as_ptr() as *mut f32,
                 xa.as_ptr() as *mut f32,
                 ta.as_ptr() as *mut f32,
@@ -48,7 +49,7 @@ pub mod binomial_put {
         result: &mut [f32], count: usize,
     ) -> f64 {
         unsafe {
-            options::binomial_put_ispc(
+            self::options::binomial_put_ispc(
                 sa.as_ptr() as *mut f32,
                 xa.as_ptr() as *mut f32,
                 ta.as_ptr() as *mut f32,
@@ -65,7 +66,7 @@ pub mod binomial_put {
         result: &mut [f32], count: usize,
     ) -> f64 {
         unsafe {
-            options::binomial_put_ispc_tasks(
+            self::options::binomial_put_ispc_tasks(
                 sa.as_ptr() as *mut f32,
                 xa.as_ptr() as *mut f32,
                 ta.as_ptr() as *mut f32,
@@ -84,8 +85,8 @@ mod tests {
     #[test]
     fn black_scholes() {
         const NOPTS: usize = 1_000_000;
-        let mut serial = ::State::new(NOPTS);
-        let mut tasks = ::State::new(NOPTS);
+        let mut serial = crate::State::new(NOPTS);
+        let mut tasks = crate::State::new(NOPTS);
 
         let serial_sum = serial.exec(black_scholes::serial);
         let tasks_sum = tasks.exec(black_scholes::tasks);
@@ -97,8 +98,8 @@ mod tests {
     #[test]
     fn binomial_put() {
         const NOPTS: usize = 1_000_000;
-        let mut serial = ::State::new(NOPTS);
-        let mut tasks = ::State::new(NOPTS);
+        let mut serial = crate::State::new(NOPTS);
+        let mut tasks = crate::State::new(NOPTS);
 
         let serial_sum = serial.exec(binomial_put::serial);
         let tasks_sum = tasks.exec(binomial_put::tasks);

--- a/examples/options_pricing/src/lib.rs
+++ b/examples/options_pricing/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -12,15 +12,9 @@
         clippy::too_many_arguments
     )
 )]
-extern crate packed_simd;
-extern crate rayon;
 
 use packed_simd::f32x8 as f32s;
 use packed_simd::f64x8 as f64s;
-
-#[cfg(feature = "ispc")]
-#[macro_use]
-extern crate ispc;
 
 const BINOMIAL_NUM: usize = 64;
 

--- a/examples/options_pricing/src/main.rs
+++ b/examples/options_pricing/src/main.rs
@@ -1,9 +1,7 @@
+#![deny(warnings, rust_2018_idioms)]
 #![feature(custom_inner_attributes)]
 
-extern crate options_pricing_lib;
 use options_pricing_lib::*;
-
-extern crate time;
 
 #[rustfmt::skip]
 fn run<F>(name: &str, count: usize, f: F)

--- a/examples/options_pricing/src/scalar.rs
+++ b/examples/options_pricing/src/scalar.rs
@@ -38,14 +38,14 @@ pub fn black_scholes(
         let d2 = d1 - v * t.sqrt();
         result[i] = s * cnd(d1) - x * (-r * t).exp() * cnd(d2);
     }
-    ::sum::slice_scalar(&result)
+    crate::sum::slice_scalar(&result)
 }
 
 pub fn binomial_put(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    use BINOMIAL_NUM;
+    use crate::BINOMIAL_NUM;
 
     for i in 0..count {
         let s = sa[i];
@@ -75,7 +75,7 @@ pub fn binomial_put(
 
         result[i] = vs[0];
     }
-    ::sum::slice_scalar(&result)
+    crate::sum::slice_scalar(&result)
 }
 
 #[cfg(feature = "ispc")]

--- a/examples/options_pricing/src/scalar.rs
+++ b/examples/options_pricing/src/scalar.rs
@@ -82,15 +82,15 @@ pub fn binomial_put(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use almost_equal;
+    use crate::almost_equal;
     #[test]
     fn black_scholes_ispc() {
         const NOPTS: usize = 1_000_000;
-        let mut scalar = ::State::new(NOPTS);
-        let mut ispc = ::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
+        let mut ispc = crate::State::new(NOPTS);
 
         let scalar_sum = scalar.exec(black_scholes);
-        let ispc_sum = ispc.exec(::ispc_::black_scholes::serial);
+        let ispc_sum = ispc.exec(crate::ispc_::black_scholes::serial);
 
         assert_eq!(scalar, ispc);
         assert_eq!(scalar_sum, ispc_sum);
@@ -99,11 +99,11 @@ mod tests {
     #[test]
     fn binomial_put_ispc() {
         const NOPTS: usize = 1_000_000;
-        let mut scalar = ::State::new(NOPTS);
-        let mut ispc = ::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
+        let mut ispc = crate::State::new(NOPTS);
 
         let scalar_sum = scalar.exec(binomial_put);
-        let ispc_sum = ispc.exec(::ispc_::binomial_put::serial);
+        let ispc_sum = ispc.exec(crate::ispc_::binomial_put::serial);
 
         // FIXME: results differ slightly for each value of the result vector
         // need to figure out why

--- a/examples/options_pricing/src/simd.rs
+++ b/examples/options_pricing/src/simd.rs
@@ -1,6 +1,6 @@
 //! SIMD implementation
 
-use f32s;
+use crate::f32s;
 
 pub fn serial<K>(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
@@ -21,21 +21,21 @@ where
             r.write_to_slice_unaligned_unchecked(&mut result[i..]);
         }
     }
-    ::sum::slice(&result)
+    crate::sum::slice(&result)
 }
 
 pub fn black_scholes(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    serial(sa, xa, ta, ra, va, result, count, ::simd_kernels::black_scholes)
+    serial(sa, xa, ta, ra, va, result, count, crate::simd_kernels::black_scholes)
 }
 
 pub fn binomial_put(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    serial(sa, xa, ta, ra, va, result, count, ::simd_kernels::binomial_put)
+    serial(sa, xa, ta, ra, va, result, count, crate::simd_kernels::binomial_put)
 }
 
 #[cfg(test)]

--- a/examples/options_pricing/src/simd.rs
+++ b/examples/options_pricing/src/simd.rs
@@ -41,15 +41,15 @@ pub fn binomial_put(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use almost_equal;
+    use crate::almost_equal;
     #[test]
     fn black_scholes_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd = ::State::new(NOPTS);
-        let mut scalar = ::State::new(NOPTS);
+        let mut simd = crate::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
 
         let simd_sum = simd.exec(black_scholes);
-        let scalar_sum = scalar.exec(::scalar::black_scholes);
+        let scalar_sum = scalar.exec(crate::scalar::black_scholes);
 
         assert_eq!(simd, scalar);
         assert_eq!(simd_sum, scalar_sum);
@@ -58,11 +58,11 @@ mod tests {
     #[test]
     fn binomial_put_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd = ::State::new(NOPTS);
-        let mut scalar = ::State::new(NOPTS);
+        let mut simd = crate::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
 
         let simd_sum = simd.exec(binomial_put);
-        let scalar_sum = scalar.exec(::scalar::binomial_put);
+        let scalar_sum = scalar.exec(crate::scalar::binomial_put);
 
         // assert_eq!(simd, scalar);
         // assert_eq!(simd_sum, scalar_sum);

--- a/examples/options_pricing/src/simd_kernels.rs
+++ b/examples/options_pricing/src/simd_kernels.rs
@@ -1,4 +1,4 @@
-use f32s;
+use crate::f32s;
 
 // Cumulative normal distribution function
 #[inline(always)]
@@ -29,7 +29,7 @@ pub fn black_scholes(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
 
 #[inline(always)]
 pub fn binomial_put(s: f32s, x: f32s, t: f32s, r: f32s, v: f32s) -> f32s {
-    use BINOMIAL_NUM;
+    use crate::BINOMIAL_NUM;
 
     let dt = t / BINOMIAL_NUM as f32;
     let u = (v * dt.sqrt()).exp();

--- a/examples/options_pricing/src/simd_par.rs
+++ b/examples/options_pricing/src/simd_par.rs
@@ -45,15 +45,15 @@ pub fn binomial_put(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use almost_equal;
+    use crate::almost_equal;
     #[test]
     fn black_scholes_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd_par = ::State::new(NOPTS);
-        let mut scalar = ::State::new(NOPTS);
+        let mut simd_par = crate::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
 
         let simd_par_sum = simd_par.exec(black_scholes);
-        let scalar_sum = scalar.exec(::scalar::black_scholes);
+        let scalar_sum = scalar.exec(crate::scalar::black_scholes);
 
         assert_eq!(simd_par, scalar);
         assert_eq!(simd_par_sum, scalar_sum);
@@ -62,11 +62,11 @@ mod tests {
     #[test]
     fn binomial_put_scalar() {
         const NOPTS: usize = 1_000_000;
-        let mut simd_par = ::State::new(NOPTS);
-        let mut scalar = ::State::new(NOPTS);
+        let mut simd_par = crate::State::new(NOPTS);
+        let mut scalar = crate::State::new(NOPTS);
 
         let simd_par_sum = simd_par.exec(binomial_put);
-        let scalar_sum = scalar.exec(::scalar::binomial_put);
+        let scalar_sum = scalar.exec(crate::scalar::binomial_put);
 
         // assert_eq!(simd_par, scalar);
         // assert_eq!(simd_par_sum, scalar_sum);

--- a/examples/options_pricing/src/simd_par.rs
+++ b/examples/options_pricing/src/simd_par.rs
@@ -1,6 +1,6 @@
 //! SIMD implementation
 
-use f32s;
+use crate::f32s;
 
 pub fn parallel<K>(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
@@ -25,21 +25,21 @@ where
             }
         },
     );
-    ::sum::slice(&result)
+    crate::sum::slice(&result)
 }
 
 pub fn black_scholes(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    parallel(sa, xa, ta, ra, va, result, count, ::simd_kernels::black_scholes)
+    parallel(sa, xa, ta, ra, va, result, count, crate::simd_kernels::black_scholes)
 }
 
 pub fn binomial_put(
     sa: &[f32], xa: &[f32], ta: &[f32], ra: &[f32], va: &[f32],
     result: &mut [f32], count: usize,
 ) -> f64 {
-    parallel(sa, xa, ta, ra, va, result, count, ::simd_kernels::binomial_put)
+    parallel(sa, xa, ta, ra, va, result, count, crate::simd_kernels::binomial_put)
 }
 
 #[cfg(test)]

--- a/examples/slice_sum/Cargo.toml
+++ b/examples/slice_sum/Cargo.toml
@@ -2,6 +2,7 @@
 name = "slice_sum"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [[bin]]
 name = "slice_sum"

--- a/examples/slice_sum/src/main.rs
+++ b/examples/slice_sum/src/main.rs
@@ -1,9 +1,5 @@
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
-
-extern crate packed_simd;
-extern crate rand;
-extern crate rayon;
-extern crate time;
+#![deny(warnings, rust_2018_idioms)]
 
 use packed_simd::f32x8 as f32s;
 use std::{mem, slice};

--- a/examples/spectral_norm/Cargo.toml
+++ b/examples/spectral_norm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spectral_norm"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/spectral_norm/src/lib.rs
+++ b/examples/spectral_norm/src/lib.rs
@@ -1,10 +1,8 @@
 //! Spectral Norm
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![allow(non_snake_case, non_camel_case_types)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_precision_loss))]
-
-extern crate packed_simd;
 
 pub mod scalar;
 pub mod simd;

--- a/examples/spectral_norm/src/main.rs
+++ b/examples/spectral_norm/src/main.rs
@@ -3,7 +3,7 @@
 extern crate spectral_norm_lib;
 use spectral_norm_lib::*;
 
-fn run<O: ::std::io::Write>(o: &mut O, n: usize, alg: usize) {
+fn run<O: std::io::Write>(o: &mut O, n: usize, alg: usize) {
     let answer = spectral_norm(n, alg);
     writeln!(o, "{:.9}", answer).unwrap();
 }
@@ -18,7 +18,7 @@ fn main() {
         0
     };
 
-    run(&mut ::std::io::stdout(), n, alg);
+    run(&mut std::io::stdout(), n, alg);
 }
 
 #[cfg(test)]

--- a/examples/spectral_norm/src/scalar.rs
+++ b/examples/spectral_norm/src/scalar.rs
@@ -4,7 +4,7 @@ use std::{
     iter::*,
     ops::{Add, Div},
 };
-use *;
+use crate::*;
 
 struct f64x2(f64, f64);
 impl Add for f64x2 {

--- a/examples/spectral_norm/src/simd.rs
+++ b/examples/spectral_norm/src/simd.rs
@@ -1,7 +1,7 @@
 //! Vectorized spectral norm implementation
 
 use packed_simd::*;
-use *;
+use crate::*;
 
 fn mult_Av(v: &[f64], out: &mut [f64]) {
     assert!(v.len() == out.len());

--- a/examples/stencil/Cargo.toml
+++ b/examples/stencil/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stencil"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 packed_simd = { path = "../.." }

--- a/examples/stencil/build.rs
+++ b/examples/stencil/build.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "ispc")]
-extern crate ispc;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/examples/stencil/src/ispc_loops.rs
+++ b/examples/stencil/src/ispc_loops.rs
@@ -1,5 +1,6 @@
 //! Includes the ISPC implementations.
 
+use ispc::*;
 ispc_module!(stencil);
 
 pub fn serial(
@@ -8,7 +9,7 @@ pub fn serial(
     a_even: &mut [f32], a_odd: &mut [f32],
 ) {
     unsafe {
-        stencil::loop_stencil_ispc(
+        self::stencil::loop_stencil_ispc(
             t0,
             t1,
             x0,
@@ -34,7 +35,7 @@ pub fn tasks(
     a_even: &mut [f32], a_odd: &mut [f32],
 ) {
     unsafe {
-        stencil::loop_stencil_ispc_tasks(
+        self::stencil::loop_stencil_ispc_tasks(
             t0,
             t1,
             x0,

--- a/examples/stencil/src/lib.rs
+++ b/examples/stencil/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(custom_inner_attributes, stmt_expr_attributes)]
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![cfg_attr(feature = "cargo-clippy", feature(tool_lints))]
 #![cfg_attr(
     feature = "cargo-clippy",
@@ -13,13 +13,6 @@
         clippy::inline_always
     )
 )]
-
-extern crate packed_simd;
-extern crate rayon;
-
-#[cfg(feature = "ispc")]
-#[macro_use]
-extern crate ispc;
 
 #[cfg(feature = "ispc")]
 pub mod ispc_loops;

--- a/examples/stencil/src/main.rs
+++ b/examples/stencil/src/main.rs
@@ -21,13 +21,13 @@ fn main() {
     let alg: usize = args.next().unwrap().parse().unwrap();
 
     match alg {
-        0 => run("scalar", scalar::scalar),
-        1 => run("vector", simd::x8),
-        2 => run("vector_par", simd_par::x8_par),
+        0 => run("scalar", self::scalar::scalar),
+        1 => run("vector", self::simd::x8),
+        2 => run("vector_par", self::simd_par::x8_par),
         3 => {
             #[cfg(feature = "ispc")]
             {
-                run("ispc", ispc_loops::serial);
+                run("ispc", self::ispc_loops::serial);
             }
             #[cfg(not(feature = "ispc"))]
             {
@@ -37,7 +37,7 @@ fn main() {
         4 => {
             #[cfg(feature = "ispc")]
             {
-                run("ispc+tasks", ispc_loops::tasks);
+                run("ispc+tasks", self::ispc_loops::tasks);
             }
             #[cfg(not(feature = "ispc"))]
             {

--- a/examples/stencil/src/main.rs
+++ b/examples/stencil/src/main.rs
@@ -1,9 +1,6 @@
 #![feature(custom_inner_attributes)]
 
-extern crate stencil_lib;
 use stencil_lib::*;
-
-extern crate time;
 
 use std::env;
 

--- a/examples/stencil/src/scalar.rs
+++ b/examples/stencil/src/scalar.rs
@@ -63,8 +63,8 @@ pub fn scalar(
 #[cfg(all(test, feature = "ispc"))]
 mod tests {
     use super::scalar;
-    use ispc_loops::serial;
-    use {assert_data_eq, Data};
+    use crate::ispc_loops::serial;
+    use crate::{assert_data_eq, Data};
 
     #[test]
 

--- a/examples/stencil/src/simd.rs
+++ b/examples/stencil/src/simd.rs
@@ -205,8 +205,8 @@ pub fn x8(
 #[cfg(test)]
 mod tests {
     use super::x8;
-    use scalar::scalar;
-    use {assert_data_eq, Data};
+    use crate::scalar::scalar;
+    use crate::{assert_data_eq, Data};
 
     #[test]
     fn simd_scalar_verify() {
@@ -222,7 +222,7 @@ mod tests {
     #[cfg(feature = "ispc")]
     #[test]
     fn simd_ispc_verify() {
-        use ispc_loops::serial;
+        use crate::ispc_loops::serial;
 
         let mut data_simd = Data::default();
         data_simd.exec(x8);

--- a/examples/stencil/src/simd_par.rs
+++ b/examples/stencil/src/simd_par.rs
@@ -1,6 +1,6 @@
 //! SIMD+Rayon implementation.
 use rayon::prelude::*;
-use simd::step_x8;
+use crate::simd::step_x8;
 
 #[inline(always)]
 fn x8_par_impl(

--- a/examples/stencil/src/simd_par.rs
+++ b/examples/stencil/src/simd_par.rs
@@ -146,8 +146,8 @@ pub fn x8_par(
 #[cfg(test)]
 mod tests {
     use super::x8_par;
-    use scalar::scalar;
-    use {assert_data_eq, Data};
+    use crate::scalar::scalar;
+    use crate::{assert_data_eq, Data};
 
     #[test]
     fn simd_par_verify() {

--- a/micro_benchmarks/Cargo.toml
+++ b/micro_benchmarks/Cargo.toml
@@ -3,6 +3,7 @@ name = "micro_benchmarks"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 autobenches = false
+edition = "2018"
 
 [dev-dependencies]
 packed_simd = { path = ".." }

--- a/micro_benchmarks/benches/mask_reductions.rs
+++ b/micro_benchmarks/benches/mask_reductions.rs
@@ -1,15 +1,11 @@
 //! Benchmarks for the mask reductions `all`, `any`, and `none`.
+#![deny(warnings, rust_2018_idioms)]
 #![feature(plugin, test)]
 #![plugin(interpolate_idents)]
 
-extern crate test;
 use test::black_box;
-
-extern crate packed_simd;
 use packed_simd::*;
 
-#[macro_use]
-extern crate criterion;
 use criterion::{Benchmark, Criterion, Throughput};
 const NO_ITERATIONS: u32 = 1_000;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -229,7 +229,7 @@ macro_rules! impl_m {
         impl_fmt_debug!([bool; $elem_n]: $tuple_id | $test_tt);
         impl_from_array!(
             [$elem_ty; $elem_n]: $tuple_id | $test_tt
-            | ($elem_ty::new(true), true)
+            | (crate::$elem_ty::new(true), true)
         );
         impl_from_vectors!(
             [$elem_ty; $elem_n]: $tuple_id | $test_tt | $($from_vec_ty),*

--- a/src/api/cast.rs
+++ b/src/api/cast.rs
@@ -29,9 +29,9 @@
 /// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
 ///
 /// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
-pub trait FromCast<T>: ::marker::Sized {
+pub trait FromCast<T>: crate::marker::Sized {
     /// Numeric cast from `T` to `Self`.
-    fn from_cast(T) -> Self;
+    fn from_cast(_: T) -> Self;
 }
 
 /// Numeric cast from `Self` to `T`.
@@ -62,7 +62,7 @@ pub trait FromCast<T>: ::marker::Sized {
 /// * casting from an `f64` to an `f32` **rounds to nearest, ties to even**.
 ///
 /// [RFC2484]: https://github.com/rust-lang/rfcs/pull/2484
-pub trait Cast<T>: ::marker::Sized {
+pub trait Cast<T>: crate::marker::Sized {
     /// Numeric cast from `self` to `T`.
     fn cast(self) -> T;
 }

--- a/src/api/cast/macros.rs
+++ b/src/api/cast/macros.rs
@@ -5,7 +5,7 @@ macro_rules! impl_from_cast_ {
         impl crate::api::cast::FromCast<$from_ty> for $id {
             #[inline]
             fn from_cast(x: $from_ty) -> Self {
-                use codegen::llvm::simd_cast;
+                use crate::codegen::llvm::simd_cast;
                 debug_assert_eq!($from_ty::lanes(), $id::lanes());
                 Simd(unsafe { simd_cast(x.0) })
             }

--- a/src/api/cmp/eq.rs
+++ b/src/api/cmp/eq.rs
@@ -6,8 +6,8 @@ macro_rules! impl_cmp_eq {
         $id:ident | $test_tt:tt |
         ($true:expr, $false:expr)
     ) => {
-        impl ::cmp::Eq for $id {}
-        impl ::cmp::Eq for LexicographicallyOrdered<$id> {}
+        impl crate::cmp::Eq for $id {}
+        impl crate::cmp::Eq for LexicographicallyOrdered<$id> {}
 
         test_if!{
             $test_tt:
@@ -16,7 +16,7 @@ macro_rules! impl_cmp_eq {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn eq() {
-                        fn foo<E: ::cmp::Eq>(_: E) {}
+                        fn foo<E: crate::cmp::Eq>(_: E) {}
                         let a = $id::splat($false);
                         foo(a);
                     }

--- a/src/api/cmp/ord.rs
+++ b/src/api/cmp/ord.rs
@@ -14,12 +14,12 @@ macro_rules! impl_cmp_ord {
             }
         }
 
-        impl ::cmp::Ord for LexicographicallyOrdered<$id> {
+        impl crate::cmp::Ord for LexicographicallyOrdered<$id> {
             #[inline]
-            fn cmp(&self, other: &Self) -> ::cmp::Ordering {
+            fn cmp(&self, other: &Self) -> crate::cmp::Ordering {
                 match self.partial_cmp(other) {
                     Some(x) => x,
-                    None => unsafe { ::hint::unreachable_unchecked() },
+                    None => unsafe { crate::hint::unreachable_unchecked() },
                 }
             }
         }
@@ -31,7 +31,7 @@ macro_rules! impl_cmp_ord {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn eq() {
-                        fn foo<E: ::cmp::Ord>(_: E) {}
+                        fn foo<E: crate::cmp::Ord>(_: E) {}
                         let a = $id::splat($false);
                         foo(a.partial_lex_ord());
                         foo(a.lex_ord());

--- a/src/api/cmp/partial_eq.rs
+++ b/src/api/cmp/partial_eq.rs
@@ -8,7 +8,7 @@ macro_rules! impl_cmp_partial_eq {
     ) => {
         // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2892
         #[cfg_attr(feature = "cargo-clippy", allow(clippy::partialeq_ne_impl))]
-        impl ::cmp::PartialEq<$id> for $id {
+        impl crate::cmp::PartialEq<$id> for $id {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 $id::eq(*self, *other).all()
@@ -21,7 +21,7 @@ macro_rules! impl_cmp_partial_eq {
 
         // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2892
         #[cfg_attr(feature = "cargo-clippy", allow(clippy::partialeq_ne_impl))]
-        impl ::cmp::PartialEq<LexicographicallyOrdered<$id>>
+        impl crate::cmp::PartialEq<LexicographicallyOrdered<$id>>
             for LexicographicallyOrdered<$id>
         {
             #[inline]

--- a/src/api/cmp/partial_ord.rs
+++ b/src/api/cmp/partial_ord.rs
@@ -12,17 +12,19 @@ macro_rules! impl_cmp_partial_ord {
             }
         }
 
-        impl ::cmp::PartialOrd<LexicographicallyOrdered<$id>>
+        impl crate::cmp::PartialOrd<LexicographicallyOrdered<$id>>
             for LexicographicallyOrdered<$id>
         {
             #[inline]
-            fn partial_cmp(&self, other: &Self) -> Option<::cmp::Ordering> {
+            fn partial_cmp(
+                &self, other: &Self,
+            ) -> Option<crate::cmp::Ordering> {
                 if PartialEq::eq(self, other) {
-                    Some(::cmp::Ordering::Equal)
+                    Some(crate::cmp::Ordering::Equal)
                 } else if PartialOrd::lt(self, other) {
-                    Some(::cmp::Ordering::Less)
+                    Some(crate::cmp::Ordering::Less)
                 } else if PartialOrd::gt(self, other) {
-                    Some(::cmp::Ordering::Greater)
+                    Some(crate::cmp::Ordering::Greater)
                 } else {
                     None
                 }
@@ -72,7 +74,7 @@ macro_rules! test_cmp_partial_ord_int {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn partial_lex_ord() {
-                        use ::testing::utils::{test_cmp};
+                        use crate::testing::utils::{test_cmp};
                         // constant values
                         let a = $id::splat(0);
                         let b = $id::splat(1);
@@ -159,7 +161,7 @@ macro_rules! test_cmp_partial_ord_mask {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn partial_lex_ord() {
-                        use ::testing::utils::{test_cmp};
+                        use crate::testing::utils::{test_cmp};
                         // constant values
                         let a = $id::splat(false);
                         let b = $id::splat(true);

--- a/src/api/cmp/partial_ord.rs
+++ b/src/api/cmp/partial_ord.rs
@@ -80,13 +80,13 @@ macro_rules! test_cmp_partial_ord_int {
                         let b = $id::splat(1);
 
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(crate::cmp::Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(crate::cmp::Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
 
                         // variable values: a = [0, 1, 2, 3]; b = [3, 2, 1, 0]
                         let mut a = $id::splat(0);
@@ -96,26 +96,26 @@ macro_rules! test_cmp_partial_ord_int {
                             b = b.replace(i, ($id::lanes() - i) as $elem_ty);
                         }
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(crate::cmp::Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(crate::cmp::Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
 
                         // variable values: a = [0, 1, 2, 3]; b = [0, 1, 2, 4]
                         let mut b = a;
                         b = b.replace($id::lanes()-1,
                                       a.extract($id::lanes() - 1) + 1 as $elem_ty);
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(crate::cmp::Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(crate::cmp::Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(crate::cmp::Ordering::Equal));
 
                         if $id::lanes() > 2 {
                             // variable values a = [0, 1, 0, 0]; b = [0, 1, 2, 3]
@@ -123,13 +123,13 @@ macro_rules! test_cmp_partial_ord_int {
                             let mut a = $id::splat(0);
                             a = a.replace(1, 1 as $elem_ty);
                             test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Less));
+                                     Some(crate::cmp::Ordering::Less));
                             test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Greater));
+                                     Some(crate::cmp::Ordering::Greater));
                             test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(crate::cmp::Ordering::Equal));
                             test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(crate::cmp::Ordering::Equal));
 
                             // variable values: a = [0, 1, 2, 3]; b = [0, 1, 3, 2]
                             let mut b = a;
@@ -137,13 +137,13 @@ macro_rules! test_cmp_partial_ord_int {
                                 2, a.extract($id::lanes() - 1) + 1 as $elem_ty
                             );
                             test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Less));
+                                     Some(crate::cmp::Ordering::Less));
                             test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Greater));
+                                     Some(crate::cmp::Ordering::Greater));
                             test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(crate::cmp::Ordering::Equal));
                             test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(crate::cmp::Ordering::Equal));
                         }
                     }
                 }
@@ -162,18 +162,20 @@ macro_rules! test_cmp_partial_ord_mask {
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn partial_lex_ord() {
                         use crate::testing::utils::{test_cmp};
+                        use crate::cmp::Ordering;
+
                         // constant values
                         let a = $id::splat(false);
                         let b = $id::splat(true);
 
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
 
                         // variable values:
                         // a = [false, false, false, false];
@@ -182,13 +184,13 @@ macro_rules! test_cmp_partial_ord_mask {
                         let mut b = $id::splat(false);
                         b = b.replace($id::lanes() - 1, true);
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
 
                         // variable values:
                         // a = [true, true, true, false];
@@ -197,13 +199,13 @@ macro_rules! test_cmp_partial_ord_mask {
                         let b = $id::splat(true);
                         a = a.replace($id::lanes() - 1, false);
                         test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Less));
+                                 Some(Ordering::Less));
                         test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Greater));
+                                 Some(Ordering::Greater));
                         test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
                         test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                 Some(::cmp::Ordering::Equal));
+                                 Some(Ordering::Equal));
 
                         if $id::lanes() > 2 {
                             // variable values
@@ -214,13 +216,13 @@ macro_rules! test_cmp_partial_ord_mask {
                             a = a.replace(1, true);
                             b = b.replace(0, false);
                             test_cmp(a.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Less));
+                                     Some(Ordering::Less));
                             test_cmp(b.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Greater));
+                                     Some(Ordering::Greater));
                             test_cmp(a.partial_lex_ord(), a.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(Ordering::Equal));
                             test_cmp(b.partial_lex_ord(), b.partial_lex_ord(),
-                                     Some(::cmp::Ordering::Equal));
+                                     Some(Ordering::Equal));
                         }
                     }
                 }

--- a/src/api/cmp/vertical.rs
+++ b/src/api/cmp/vertical.rs
@@ -11,21 +11,21 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise equality comparison.
             #[inline]
             pub fn eq(self, other: Self) -> $mask_ty {
-                use crate::llvm::simd_eq;
+                use super::llvm::simd_eq;
                 Simd(unsafe { simd_eq(self.0, other.0) })
             }
 
             /// Lane-wise inequality comparison.
             #[inline]
             pub fn ne(self, other: Self) -> $mask_ty {
-                use crate::llvm::simd_ne;
+                use super::llvm::simd_ne;
                 Simd(unsafe { simd_ne(self.0, other.0) })
             }
 
             /// Lane-wise less-than comparison.
             #[inline]
             pub fn lt(self, other: Self) -> $mask_ty {
-                use crate::llvm::{simd_gt, simd_lt};
+                use super::llvm::{simd_gt, simd_lt};
                 if $is_mask {
                     Simd(unsafe { simd_gt(self.0, other.0) })
                 } else {
@@ -36,7 +36,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise less-than-or-equals comparison.
             #[inline]
             pub fn le(self, other: Self) -> $mask_ty {
-                use crate::llvm::{simd_ge, simd_le};
+                use super::llvm::{simd_ge, simd_le};
                 if $is_mask {
                     Simd(unsafe { simd_ge(self.0, other.0) })
                 } else {
@@ -47,7 +47,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise greater-than comparison.
             #[inline]
             pub fn gt(self, other: Self) -> $mask_ty {
-                use crate::llvm::{simd_gt, simd_lt};
+                use super::llvm::{simd_gt, simd_lt};
                 if $is_mask {
                     Simd(unsafe { simd_lt(self.0, other.0) })
                 } else {
@@ -58,7 +58,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise greater-than-or-equals comparison.
             #[inline]
             pub fn ge(self, other: Self) -> $mask_ty {
-                use crate::llvm::{simd_ge, simd_le};
+                use super::llvm::{simd_ge, simd_le};
                 if $is_mask {
                     Simd(unsafe { simd_le(self.0, other.0) })
                 } else {

--- a/src/api/cmp/vertical.rs
+++ b/src/api/cmp/vertical.rs
@@ -11,21 +11,21 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise equality comparison.
             #[inline]
             pub fn eq(self, other: Self) -> $mask_ty {
-                use llvm::simd_eq;
+                use crate::llvm::simd_eq;
                 Simd(unsafe { simd_eq(self.0, other.0) })
             }
 
             /// Lane-wise inequality comparison.
             #[inline]
             pub fn ne(self, other: Self) -> $mask_ty {
-                use llvm::simd_ne;
+                use crate::llvm::simd_ne;
                 Simd(unsafe { simd_ne(self.0, other.0) })
             }
 
             /// Lane-wise less-than comparison.
             #[inline]
             pub fn lt(self, other: Self) -> $mask_ty {
-                use llvm::{simd_gt, simd_lt};
+                use crate::llvm::{simd_gt, simd_lt};
                 if $is_mask {
                     Simd(unsafe { simd_gt(self.0, other.0) })
                 } else {
@@ -36,7 +36,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise less-than-or-equals comparison.
             #[inline]
             pub fn le(self, other: Self) -> $mask_ty {
-                use llvm::{simd_ge, simd_le};
+                use crate::llvm::{simd_ge, simd_le};
                 if $is_mask {
                     Simd(unsafe { simd_ge(self.0, other.0) })
                 } else {
@@ -47,7 +47,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise greater-than comparison.
             #[inline]
             pub fn gt(self, other: Self) -> $mask_ty {
-                use llvm::{simd_gt, simd_lt};
+                use crate::llvm::{simd_gt, simd_lt};
                 if $is_mask {
                     Simd(unsafe { simd_lt(self.0, other.0) })
                 } else {
@@ -58,7 +58,7 @@ macro_rules! impl_cmp_vertical {
             /// Lane-wise greater-than-or-equals comparison.
             #[inline]
             pub fn ge(self, other: Self) -> $mask_ty {
-                use llvm::{simd_ge, simd_le};
+                use crate::llvm::{simd_ge, simd_le};
                 if $is_mask {
                     Simd(unsafe { simd_le(self.0, other.0) })
                 } else {

--- a/src/api/default.rs
+++ b/src/api/default.rs
@@ -2,7 +2,7 @@
 
 macro_rules! impl_default {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::default::Default for $id {
+        impl Default for $id {
             #[inline]
             fn default() -> Self {
                 Self::splat($elem_ty::default())

--- a/src/api/fmt/binary.rs
+++ b/src/api/fmt/binary.rs
@@ -2,11 +2,11 @@
 
 macro_rules! impl_fmt_binary {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::fmt::Binary for $id {
+        impl crate::fmt::Binary for $id {
             #[cfg_attr(
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;

--- a/src/api/fmt/binary.rs
+++ b/src/api/fmt/binary.rs
@@ -29,7 +29,7 @@ macro_rules! impl_fmt_binary {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::splat($elem_ty::default());
                         let mut s = TinyString::new();
                         write!(&mut s, "{:#b}", v).unwrap();

--- a/src/api/fmt/debug.rs
+++ b/src/api/fmt/debug.rs
@@ -12,7 +12,7 @@ macro_rules! impl_fmt_debug_tests {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::default();
                         let mut s = TinyString::new();
                         write!(&mut s, "{:?}", v).unwrap();

--- a/src/api/fmt/debug.rs
+++ b/src/api/fmt/debug.rs
@@ -41,12 +41,14 @@ macro_rules! impl_fmt_debug_tests {
 
 macro_rules! impl_fmt_debug {
     ([$elem_ty:ty; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::fmt::Debug for $id {
+        impl crate::fmt::Debug for $id {
             #[cfg_attr(
                 feature = "cargo-clippy",
                 allow(clippy::missing_inline_in_public_items)
             )]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(
+                &self, f: &mut crate::fmt::Formatter<'_>,
+            ) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(
                     feature = "cargo-clippy", allow(clippy::write_literal)

--- a/src/api/fmt/lower_hex.rs
+++ b/src/api/fmt/lower_hex.rs
@@ -2,11 +2,11 @@
 
 macro_rules! impl_fmt_lower_hex {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::fmt::LowerHex for $id {
+        impl crate::fmt::LowerHex for $id {
             #[cfg_attr(
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;

--- a/src/api/fmt/lower_hex.rs
+++ b/src/api/fmt/lower_hex.rs
@@ -29,7 +29,7 @@ macro_rules! impl_fmt_lower_hex {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::splat($elem_ty::default());
                         let mut s = TinyString::new();
                         write!(&mut s, "{:#x}", v).unwrap();

--- a/src/api/fmt/octal.rs
+++ b/src/api/fmt/octal.rs
@@ -29,7 +29,7 @@ macro_rules! impl_fmt_octal {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::splat($elem_ty::default());
                         let mut s = TinyString::new();
                         write!(&mut s, "{:#o}", v).unwrap();

--- a/src/api/fmt/octal.rs
+++ b/src/api/fmt/octal.rs
@@ -2,11 +2,11 @@
 
 macro_rules! impl_fmt_octal {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::fmt::Octal for $id {
+        impl crate::fmt::Octal for $id {
             #[cfg_attr(
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;

--- a/src/api/fmt/upper_hex.rs
+++ b/src/api/fmt/upper_hex.rs
@@ -29,7 +29,7 @@ macro_rules! impl_fmt_upper_hex {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::splat($elem_ty::default());
                         let mut s = TinyString::new();
                         write!(&mut s, "{:#X}", v).unwrap();

--- a/src/api/fmt/upper_hex.rs
+++ b/src/api/fmt/upper_hex.rs
@@ -2,11 +2,11 @@
 
 macro_rules! impl_fmt_upper_hex {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::fmt::UpperHex for $id {
+        impl crate::fmt::UpperHex for $id {
             #[cfg_attr(
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;

--- a/src/api/from/from_array.rs
+++ b/src/api/from/from_array.rs
@@ -76,7 +76,7 @@ macro_rules! impl_from_array {
                             // so we can take a reference to it:
                             let p = unsafe { &mut array.other as *mut () as *mut $elem_ty };
                             // note: default is a valid bit-pattern for $elem_ty:
-                            unsafe { ::ptr::write(p.wrapping_add(i), default) };
+                            unsafe { crate::ptr::write(p.wrapping_add(i), default) };
                         }
                         // note: the array variant of the union is properly initialized:
                         let mut array = unsafe { array.array };

--- a/src/api/from/from_vector.rs
+++ b/src/api/from/from_vector.rs
@@ -11,7 +11,7 @@ macro_rules! impl_from_vector {
                     U: crate::sealed::Simd<LanesType = T::LanesType>,
                 {
                 }
-                use crate::llvm::simd_cast;
+                use super::llvm::simd_cast;
                 static_assert_same_number_of_lanes::<$id, $source>();
                 Simd(unsafe { simd_cast(source.0) })
             }

--- a/src/api/from/from_vector.rs
+++ b/src/api/from/from_vector.rs
@@ -11,7 +11,7 @@ macro_rules! impl_from_vector {
                     U: crate::sealed::Simd<LanesType = T::LanesType>,
                 {
                 }
-                use llvm::simd_cast;
+                use crate::llvm::simd_cast;
                 static_assert_same_number_of_lanes::<$id, $source>();
                 Simd(unsafe { simd_cast(source.0) })
             }

--- a/src/api/hash.rs
+++ b/src/api/hash.rs
@@ -2,9 +2,9 @@
 
 macro_rules! impl_hash {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::hash::Hash for $id {
+        impl crate::hash::Hash for $id {
             #[inline]
-            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
+            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
                 unsafe {
                     union A {
                         data: [$elem_ty; $id::lanes()],
@@ -22,12 +22,12 @@ macro_rules! impl_hash {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn hash() {
-                        use ::hash::{Hash, Hasher};
+                        use crate::hash::{Hash, Hasher};
                         #[allow(deprecated)]
-                        use ::hash::{SipHasher13};
+                        use crate::hash::{SipHasher13};
                         type A = [$elem_ty; $id::lanes()];
                         let a: A = [42 as $elem_ty; $id::lanes()];
-                        assert!(mem::size_of::<A>() == mem::size_of::<$id>());
+                        assert!(crate::mem::size_of::<A>() == crate::mem::size_of::<$id>());
                         #[allow(deprecated)]
                         let mut a_hash = SipHasher13::new();
                         let mut v_hash = a_hash.clone();

--- a/src/api/into_bits.rs
+++ b/src/api/into_bits.rs
@@ -1,13 +1,13 @@
 //! Implementation of `FromBits` and `IntoBits`.
 
 /// Safe lossless bitwise conversion from `T` to `Self`.
-pub trait FromBits<T>: ::marker::Sized {
+pub trait FromBits<T>: crate::marker::Sized {
     /// Safe lossless bitwise transmute from `T` to `Self`.
-    fn from_bits(T) -> Self;
+    fn from_bits(t: T) -> Self;
 }
 
 /// Safe lossless bitwise conversion from `Self` to `T`.
-pub trait IntoBits<T>: ::marker::Sized {
+pub trait IntoBits<T>: crate::marker::Sized {
     /// Safe lossless bitwise transmute from `self` to `T`.
     fn into_bits(self) -> T;
 }
@@ -19,7 +19,7 @@ where
 {
     #[inline]
     fn into_bits(self) -> U {
-        debug_assert!(::mem::size_of::<Self>() == ::mem::size_of::<U>());
+        debug_assert!(crate::mem::size_of::<Self>() == crate::mem::size_of::<U>());
         U::from_bits(self)
     }
 }

--- a/src/api/into_bits/macros.rs
+++ b/src/api/into_bits/macros.rs
@@ -16,7 +16,7 @@ macro_rules! impl_from_bits_ {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn test() {
-                        use crate::{ptr::{read_unaligned}, crate::mem::{size_of, zeroed}};
+                        use crate::{ptr::{read_unaligned}, mem::{size_of, zeroed}};
                         use crate::IntoBits;
                         assert_eq!(size_of::<$id>(),
                                    size_of::<$from_ty>());

--- a/src/api/into_bits/macros.rs
+++ b/src/api/into_bits/macros.rs
@@ -5,7 +5,7 @@ macro_rules! impl_from_bits_ {
         impl crate::api::into_bits::FromBits<$from_ty> for $id {
             #[inline]
             fn from_bits(x: $from_ty) -> Self {
-                unsafe { ::mem::transmute(x) }
+                unsafe { crate::mem::transmute(x) }
             }
         }
 
@@ -16,15 +16,15 @@ macro_rules! impl_from_bits_ {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn test() {
-                        use ::{ptr::{read_unaligned}, mem::{size_of, zeroed}};
-                        use ::IntoBits;
+                        use crate::{ptr::{read_unaligned}, crate::mem::{size_of, zeroed}};
+                        use crate::IntoBits;
                         assert_eq!(size_of::<$id>(),
                                    size_of::<$from_ty>());
                         // This is safe becasue we never create a reference
                         // to uninitialized memory:
                         let a: $from_ty = unsafe { zeroed() };
 
-                        let b_0: $id = ::FromBits::from_bits(a);
+                        let b_0: $id = crate::FromBits::from_bits(a);
                         let b_1: $id = a.into_bits();
 
                         // Check that these are byte-wise equal, that is,

--- a/src/api/math/float/cos.rs
+++ b/src/api/math/float/cos.rs
@@ -25,7 +25,7 @@ macro_rules! impl_math_float_cos {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn cos() {
-                        use $elem_ty::consts::PI;
+                        use crate::$elem_ty::consts::PI;
                         let z = $id::splat(0 as $elem_ty);
                         let o = $id::splat(1 as $elem_ty);
                         let p = $id::splat(PI as $elem_ty);

--- a/src/api/math/float/exp.rs
+++ b/src/api/math/float/exp.rs
@@ -22,7 +22,7 @@ macro_rules! impl_math_float_exp {
                         let o = $id::splat(1 as $elem_ty);
                         assert_eq!(o, z.exp());
 
-                        let e = $id::splat(::core::f64::consts::E as $elem_ty);
+                        let e = $id::splat(::crate::f64::consts::E as $elem_ty);
                         let tol = $id::splat(2.4e-4 as $elem_ty);
                         assert!((e - o.exp()).abs().le(tol).all());
                     }

--- a/src/api/math/float/exp.rs
+++ b/src/api/math/float/exp.rs
@@ -22,7 +22,7 @@ macro_rules! impl_math_float_exp {
                         let o = $id::splat(1 as $elem_ty);
                         assert_eq!(o, z.exp());
 
-                        let e = $id::splat(::crate::f64::consts::E as $elem_ty);
+                        let e = $id::splat(crate::f64::consts::E as $elem_ty);
                         let tol = $id::splat(2.4e-4 as $elem_ty);
                         assert!((e - o.exp()).abs().le(tol).all());
                     }

--- a/src/api/math/float/ln.rs
+++ b/src/api/math/float/ln.rs
@@ -22,7 +22,7 @@ macro_rules! impl_math_float_ln {
                         let o = $id::splat(1 as $elem_ty);
                         assert_eq!(z, o.ln());
 
-                        let e = $id::splat(::core::f64::consts::E as $elem_ty);
+                        let e = $id::splat(::crate::f64::consts::E as $elem_ty);
                         let tol = $id::splat(2.4e-4 as $elem_ty);
                         assert!((o - e.ln()).abs().le(tol).all());
                     }

--- a/src/api/math/float/ln.rs
+++ b/src/api/math/float/ln.rs
@@ -22,7 +22,7 @@ macro_rules! impl_math_float_ln {
                         let o = $id::splat(1 as $elem_ty);
                         assert_eq!(z, o.ln());
 
-                        let e = $id::splat(::crate::f64::consts::E as $elem_ty);
+                        let e = $id::splat(crate::f64::consts::E as $elem_ty);
                         let tol = $id::splat(2.4e-4 as $elem_ty);
                         assert!((o - e.ln()).abs().le(tol).all());
                     }

--- a/src/api/math/float/rsqrte.rs
+++ b/src/api/math/float/rsqrte.rs
@@ -9,7 +9,7 @@ macro_rules! impl_math_float_rsqrte {
             #[inline]
             pub fn rsqrte(self) -> Self {
                 unsafe {
-                    use llvm::simd_fsqrt;
+                    use crate::llvm::simd_fsqrt;
                     $id::splat(1.) / Simd(simd_fsqrt(self.0))
                 }
             }

--- a/src/api/math/float/rsqrte.rs
+++ b/src/api/math/float/rsqrte.rs
@@ -9,7 +9,7 @@ macro_rules! impl_math_float_rsqrte {
             #[inline]
             pub fn rsqrte(self) -> Self {
                 unsafe {
-                    use crate::llvm::simd_fsqrt;
+                    use super::llvm::simd_fsqrt;
                     $id::splat(1.) / Simd(simd_fsqrt(self.0))
                 }
             }
@@ -22,7 +22,7 @@ macro_rules! impl_math_float_rsqrte {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn rsqrte() {
-                        use $elem_ty::consts::SQRT_2;
+                        use crate::$elem_ty::consts::SQRT_2;
                         let tol = $id::splat(2.4e-4 as $elem_ty);
                         let o = $id::splat(1 as $elem_ty);
                         let error = (o - o.rsqrte()).abs();

--- a/src/api/math/float/sin.rs
+++ b/src/api/math/float/sin.rs
@@ -32,7 +32,7 @@ macro_rules! impl_math_float_sin {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn sin() {
-                        use $elem_ty::consts::PI;
+                        use crate::$elem_ty::consts::PI;
                         let z = $id::splat(0 as $elem_ty);
                         let p = $id::splat(PI as $elem_ty);
                         let ph = $id::splat(PI as $elem_ty / 2.);

--- a/src/api/math/float/sqrt.rs
+++ b/src/api/math/float/sqrt.rs
@@ -17,7 +17,7 @@ macro_rules! impl_math_float_sqrt {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn sqrt() {
-                        use $elem_ty::consts::SQRT_2;
+                        use crate::$elem_ty::consts::SQRT_2;
                         let z = $id::splat(0 as $elem_ty);
                         let o = $id::splat(1 as $elem_ty);
                         assert_eq!(z, z.sqrt());

--- a/src/api/math/float/sqrte.rs
+++ b/src/api/math/float/sqrte.rs
@@ -20,7 +20,7 @@ macro_rules! impl_math_float_sqrte {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn sqrte() {
-                        use $elem_ty::consts::SQRT_2;
+                        use crate::$elem_ty::consts::SQRT_2;
                         let tol = $id::splat(2.4e-4 as $elem_ty);
 
                         let z = $id::splat(0 as $elem_ty);

--- a/src/api/minimal/iuf.rs
+++ b/src/api/minimal/iuf.rs
@@ -60,7 +60,7 @@ macro_rules! impl_minimal_iuf {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> $elem_ty {
-                use llvm::simd_extract;
+                use crate::llvm::simd_extract;
                 let e: $ielem_ty = simd_extract(self.0, index as u32);
                 e as $elem_ty
             }
@@ -89,7 +89,7 @@ macro_rules! impl_minimal_iuf {
                 index: usize,
                 new_value: $elem_ty,
             ) -> Self {
-                use llvm::simd_insert;
+                use crate::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, new_value as $ielem_ty))
             }
         }

--- a/src/api/minimal/iuf.rs
+++ b/src/api/minimal/iuf.rs
@@ -60,7 +60,7 @@ macro_rules! impl_minimal_iuf {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> $elem_ty {
-                use crate::llvm::simd_extract;
+                use super::llvm::simd_extract;
                 let e: $ielem_ty = simd_extract(self.0, index as u32);
                 e as $elem_ty
             }
@@ -89,7 +89,7 @@ macro_rules! impl_minimal_iuf {
                 index: usize,
                 new_value: $elem_ty,
             ) -> Self {
-                use crate::llvm::simd_insert;
+                use super::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, new_value as $ielem_ty))
             }
         }

--- a/src/api/minimal/mask.rs
+++ b/src/api/minimal/mask.rs
@@ -61,7 +61,7 @@ macro_rules! impl_minimal_mask {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> bool {
-                use crate::llvm::simd_extract;
+                use super::llvm::simd_extract;
                 let x: $ielem_ty = simd_extract(self.0, index as u32);
                 x != 0
             }
@@ -90,7 +90,7 @@ macro_rules! impl_minimal_mask {
                 index: usize,
                 new_value: bool,
             ) -> Self {
-                use crate::llvm::simd_insert;
+                use super::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, Self::bool_to_internal(new_value)))
             }
         }

--- a/src/api/minimal/mask.rs
+++ b/src/api/minimal/mask.rs
@@ -61,7 +61,7 @@ macro_rules! impl_minimal_mask {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> bool {
-                use llvm::simd_extract;
+                use crate::llvm::simd_extract;
                 let x: $ielem_ty = simd_extract(self.0, index as u32);
                 x != 0
             }
@@ -90,7 +90,7 @@ macro_rules! impl_minimal_mask {
                 index: usize,
                 new_value: bool,
             ) -> Self {
-                use llvm::simd_insert;
+                use crate::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, Self::bool_to_internal(new_value)))
             }
         }

--- a/src/api/minimal/ptr.rs
+++ b/src/api/minimal/ptr.rs
@@ -70,7 +70,7 @@ macro_rules! impl_minimal_p {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> $elem_ty {
-                use crate::llvm::simd_extract;
+                use super::llvm::simd_extract;
                 simd_extract(self.0, index as u32)
             }
 
@@ -99,7 +99,7 @@ macro_rules! impl_minimal_p {
                 index: usize,
                 new_value: $elem_ty,
             ) -> Self {
-                use crate::llvm::simd_insert;
+                use super::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, new_value))
             }
         }
@@ -209,7 +209,7 @@ macro_rules! impl_minimal_p {
                         use arrayvec::{ArrayString,ArrayVec};
                         type TinyString = ArrayString<[u8; 512]>;
 
-                        use fmt::Write;
+                        use crate::fmt::Write;
                         let v = $id::<i32>::default();
                         let mut s = TinyString::new();
                         write!(&mut s, "{:?}", v).unwrap();
@@ -263,7 +263,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn eq(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_eq;
+                    use super::llvm::simd_eq;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_eq(a.0, b.0))
@@ -274,7 +274,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn ne(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_ne;
+                    use super::llvm::simd_ne;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_ne(a.0, b.0))
@@ -285,7 +285,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn lt(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_lt;
+                    use super::llvm::simd_lt;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_lt(a.0, b.0))
@@ -296,7 +296,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn le(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_le;
+                    use super::llvm::simd_le;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_le(a.0, b.0))
@@ -307,7 +307,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn gt(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_gt;
+                    use super::llvm::simd_gt;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_gt(a.0, b.0))
@@ -318,7 +318,7 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn ge(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use crate::llvm::simd_ge;
+                    use super::llvm::simd_ge;
                     let a: $usize_ty = crate::mem::transmute(self);
                     let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_ge(a.0, b.0))
@@ -584,7 +584,7 @@ macro_rules! impl_minimal_p {
             interpolate_idents! {
                 pub mod [$id _slice_from_slice] {
                     use super::*;
-                    use iter::Iterator;
+                    use crate::iter::Iterator;
 
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn from_slice_unaligned() {
@@ -771,7 +771,7 @@ macro_rules! impl_minimal_p {
             interpolate_idents! {
                 pub mod [$id _slice_write_to_slice] {
                     use super::*;
-                    use iter::Iterator;
+                    use crate::iter::Iterator;
 
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn write_to_slice_unaligned() {

--- a/src/api/minimal/ptr.rs
+++ b/src/api/minimal/ptr.rs
@@ -43,7 +43,7 @@ macro_rules! impl_minimal_p {
             /// Constructs a new instance with each element initialized to `null`.
             #[inline]
             pub const fn null() -> Self {
-                Self::splat(ptr::null_mut() as $elem_ty)
+                Self::splat(crate::ptr::null_mut() as $elem_ty)
             }
 
             /// Returns a mask that selects those lanes that contain `null` pointers.
@@ -70,7 +70,7 @@ macro_rules! impl_minimal_p {
             /// If `index >= Self::lanes()` the behavior is undefined.
             #[inline]
             pub unsafe fn extract_unchecked(self, index: usize) -> $elem_ty {
-                use llvm::simd_extract;
+                use crate::llvm::simd_extract;
                 simd_extract(self.0, index as u32)
             }
 
@@ -99,7 +99,7 @@ macro_rules! impl_minimal_p {
                 index: usize,
                 new_value: $elem_ty,
             ) -> Self {
-                use llvm::simd_insert;
+                use crate::llvm::simd_insert;
                 Simd(simd_insert(self.0, index as u32, new_value))
             }
         }
@@ -145,9 +145,9 @@ macro_rules! impl_minimal_p {
                         }
 
                         let mut n = $id::<i32>::null();
-                        assert_eq!(n, $id::<i32>::splat(unsafe { mem::zeroed() }));
+                        assert_eq!(n, $id::<i32>::splat(unsafe { crate::mem::zeroed() }));
                         assert!(n.is_null().all());
-                        n = n.replace(0, unsafe { mem::transmute(1_isize) });
+                        n = n.replace(0, unsafe { crate::mem::transmute(1_isize) });
                         assert!(!n.is_null().all());
                         if $id::<i32>::lanes() > 1 {
                             assert!(n.is_null().any());
@@ -182,13 +182,13 @@ macro_rules! impl_minimal_p {
             }
         }
 
-        impl<T> ::fmt::Debug for $id<T> {
+        impl<T> crate::fmt::Debug for $id<T> {
             #[cfg_attr(feature = "cargo-clippy",
                        allow(clippy::missing_inline_in_public_items))]
-            fn fmt(&self, f: &mut ::fmt::Formatter) -> ::fmt::Result {
+            fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
                 // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
-                write!(f, "{}<{}>(", stringify!($id), unsafe { intrinsics::type_name::<T>() })?;
+                write!(f, "{}<{}>(", stringify!($id), unsafe { crate::intrinsics::type_name::<T>() })?;
                 for i in 0..$elem_count {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -234,7 +234,7 @@ macro_rules! impl_minimal_p {
             }
          }
 
-        impl<T> ::default::Default for $id<T> {
+        impl<T> Default for $id<T> {
             #[inline]
             fn default() -> Self {
                 // FIXME: ptrs do not implement default
@@ -251,7 +251,7 @@ macro_rules! impl_minimal_p {
                     fn default() {
                         let a = $id::<i32>::default();
                         for i in 0..$id::<i32>::lanes() {
-                            assert_eq!(a.extract(i), unsafe { mem::zeroed() });
+                            assert_eq!(a.extract(i), unsafe { crate::mem::zeroed() });
                         }
                     }
                 }
@@ -263,9 +263,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn eq(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_eq;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_eq;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_eq(a.0, b.0))
                 }
             }
@@ -274,9 +274,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn ne(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_ne;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_ne;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_ne(a.0, b.0))
                 }
             }
@@ -285,9 +285,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn lt(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_lt;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_lt;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_lt(a.0, b.0))
                 }
             }
@@ -296,9 +296,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn le(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_le;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_le;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_le(a.0, b.0))
                 }
             }
@@ -307,9 +307,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn gt(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_gt;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_gt;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_gt(a.0, b.0))
                 }
             }
@@ -318,9 +318,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn ge(self, other: Self) -> $mask_ty {
                 unsafe {
-                    use llvm::simd_ge;
-                    let a: $usize_ty = ::mem::transmute(self);
-                    let b: $usize_ty = ::mem::transmute(other);
+                    use crate::llvm::simd_ge;
+                    let a: $usize_ty = crate::mem::transmute(self);
+                    let b: $usize_ty = crate::mem::transmute(other);
                     Simd(simd_ge(a.0, b.0))
                 }
             }
@@ -334,7 +334,7 @@ macro_rules! impl_minimal_p {
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn cmp() {
                         let a = $id::<i32>::null();
-                        let b = $id::<i32>::splat(unsafe { mem::transmute(1_isize) });
+                        let b = $id::<i32>::splat(unsafe { crate::mem::transmute(1_isize) });
 
                         let r = a.lt(b);
                         let e = $mask_ty::splat(true);
@@ -355,12 +355,12 @@ macro_rules! impl_minimal_p {
                         let mut e = e;
                         for i in 0..$id::<i32>::lanes() {
                             if i % 2 == 0 {
-                                a = a.replace(i, unsafe { mem::transmute(0_isize) });
-                                b = b.replace(i, unsafe { mem::transmute(1_isize) });
+                                a = a.replace(i, unsafe { crate::mem::transmute(0_isize) });
+                                b = b.replace(i, unsafe { crate::mem::transmute(1_isize) });
                                 e = e.replace(i, true);
                             } else {
-                                a = a.replace(i, unsafe { mem::transmute(1_isize) });
-                                b = b.replace(i, unsafe { mem::transmute(0_isize) });
+                                a = a.replace(i, unsafe { crate::mem::transmute(1_isize) });
+                                b = b.replace(i, unsafe { crate::mem::transmute(0_isize) });
                                 e = e.replace(i, false);
                             }
                         }
@@ -372,7 +372,7 @@ macro_rules! impl_minimal_p {
         }
 
         #[cfg_attr(feature = "cargo-clippy", allow(clippy::partialeq_ne_impl))]
-        impl<T> ::cmp::PartialEq<$id<T>> for $id<T> {
+        impl<T> crate::cmp::PartialEq<$id<T>> for $id<T> {
             #[inline]
             fn eq(&self, other: &Self) -> bool {
                 $id::<T>::eq(*self, *other).all()
@@ -385,7 +385,7 @@ macro_rules! impl_minimal_p {
 
         // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2892
         #[cfg_attr(feature = "cargo-clippy", allow(clippy::partialeq_ne_impl))]
-        impl<T> ::cmp::PartialEq<LexicographicallyOrdered<$id<T>>>
+        impl<T> crate::cmp::PartialEq<LexicographicallyOrdered<$id<T>>>
             for LexicographicallyOrdered<$id<T>>
         {
             #[inline]
@@ -406,7 +406,7 @@ macro_rules! impl_minimal_p {
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn partial_eq() {
                         let a = $id::<i32>::null();
-                        let b = $id::<i32>::splat(unsafe { mem::transmute(1_isize) });
+                        let b = $id::<i32>::splat(unsafe { crate::mem::transmute(1_isize) });
 
                         assert!(a != b);
                         assert!(!(a == b));
@@ -414,8 +414,8 @@ macro_rules! impl_minimal_p {
                         assert!(!(a != a));
 
                         if $id::<i32>::lanes() > 1 {
-                            let a = $id::<i32>::null().replace(0, unsafe { mem::transmute(1_isize) });
-                            let b = $id::<i32>::splat(unsafe { mem::transmute(1_isize) });
+                            let a = $id::<i32>::null().replace(0, unsafe { crate::mem::transmute(1_isize) });
+                            let b = $id::<i32>::splat(unsafe { crate::mem::transmute(1_isize) });
 
                             assert!(a != b);
                             assert!(!(a == b));
@@ -427,8 +427,8 @@ macro_rules! impl_minimal_p {
             }
         }
 
-        impl<T> ::cmp::Eq for $id<T> {}
-        impl<T> ::cmp::Eq for LexicographicallyOrdered<$id<T>> {}
+        impl<T> crate::cmp::Eq for $id<T> {}
+        impl<T> crate::cmp::Eq for LexicographicallyOrdered<$id<T>> {}
 
         test_if!{
             $test_tt:
@@ -437,7 +437,7 @@ macro_rules! impl_minimal_p {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn eq() {
-                        fn foo<E: ::cmp::Eq>(_: E) {}
+                        fn foo<E: crate::cmp::Eq>(_: E) {}
                         let a = $id::<i32>::null();
                         foo(a);
                     }
@@ -450,11 +450,11 @@ macro_rules! impl_minimal_p {
             fn from(array: [$elem_ty; $elem_count]) -> Self {
                 unsafe {
                     // FIXME: unnecessary zeroing; better than UB.
-                    let mut u: Self = mem::zeroed();
-                    ptr::copy_nonoverlapping(
+                    let mut u: Self = crate::mem::zeroed();
+                    crate::ptr::copy_nonoverlapping(
                         &array as *const [$elem_ty; $elem_count] as *const u8,
                         &mut u as *mut Self as *mut u8,
-                        mem::size_of::<Self>()
+                        crate::mem::size_of::<Self>()
                     );
                     u
                 }
@@ -465,11 +465,11 @@ macro_rules! impl_minimal_p {
             fn into(self) -> [$elem_ty; $elem_count] {
                 unsafe {
                     // FIXME: unnecessary zeroing; better than UB.
-                    let mut u: [$elem_ty; $elem_count] = mem::zeroed();
-                    ptr::copy_nonoverlapping(
+                    let mut u: [$elem_ty; $elem_count] = crate::mem::zeroed();
+                    crate::ptr::copy_nonoverlapping(
                         &self as *const $id<T> as *const u8,
                         &mut u as *mut [$elem_ty; $elem_count] as *mut u8,
-                        mem::size_of::<Self>()
+                        crate::mem::size_of::<Self>()
                     );
                     u
                 }
@@ -489,7 +489,7 @@ macro_rules! impl_minimal_p {
                         let mut array = [$id::<i32>::null().extract(0); $elem_count];
 
                         for i in 0..$elem_count {
-                            let ptr = unsafe { mem::transmute(&values[[i]] as *const i32) };
+                            let ptr = unsafe { crate::mem::transmute(&values[[i]] as *const i32) };
                             vec = vec.replace(i, ptr);
                             array[[i]] = ptr;
                         }
@@ -524,7 +524,7 @@ macro_rules! impl_minimal_p {
                     assert!(slice.len() >= $elem_count);
                     let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
                     assert!(
-                        target_ptr.align_offset(::mem::align_of::<Self>())
+                        target_ptr.align_offset(crate::mem::align_of::<Self>())
                             == 0
                     );
                     Self::from_slice_aligned_unchecked(slice)
@@ -565,12 +565,12 @@ macro_rules! impl_minimal_p {
             pub unsafe fn from_slice_unaligned_unchecked(
                 slice: &[$elem_ty],
             ) -> Self {
-                use mem::size_of;
+                use crate::mem::size_of;
                 let target_ptr =
                     slice.get_unchecked(0) as *const $elem_ty as *const u8;
-                let mut x = Self::splat(ptr::null_mut() as $elem_ty);
+                let mut x = Self::splat(crate::ptr::null_mut() as $elem_ty);
                 let self_ptr = &mut x as *mut Self as *mut u8;
-                ptr::copy_nonoverlapping(
+                crate::ptr::copy_nonoverlapping(
                     target_ptr,
                     self_ptr,
                     size_of::<Self>(),
@@ -677,7 +677,7 @@ macro_rules! impl_minimal_p {
                             // offset pointer by one element
                             let ptr = ptr.wrapping_add(1);
 
-                            if ptr.align_offset(mem::align_of::<$id<i32>>()) == 0 {
+                            if ptr.align_offset(crate::mem::align_of::<$id<i32>>()) == 0 {
                                 // the pointer is properly aligned, so from_slice_aligned
                                 // won't fail here (e.g. this can happen for i128x1). So
                                 // we panic to make the "should_fail" test pass:
@@ -710,7 +710,7 @@ macro_rules! impl_minimal_p {
                     let target_ptr =
                         slice.get_unchecked_mut(0) as *mut $elem_ty;
                     assert!(
-                        target_ptr.align_offset(mem::align_of::<Self>())
+                        target_ptr.align_offset(crate::mem::align_of::<Self>())
                             == 0
                     );
                     self.write_to_slice_aligned_unchecked(slice);
@@ -758,10 +758,10 @@ macro_rules! impl_minimal_p {
                 let target_ptr =
                     slice.get_unchecked_mut(0) as *mut $elem_ty as *mut u8;
                 let self_ptr = &self as *const Self as *const u8;
-                ptr::copy_nonoverlapping(
+                crate::ptr::copy_nonoverlapping(
                     self_ptr,
                     target_ptr,
-                    mem::size_of::<Self>(),
+                    crate::mem::size_of::<Self>(),
                 );
             }
         }
@@ -859,7 +859,7 @@ macro_rules! impl_minimal_p {
                             // offset pointer by one element
                             let ptr = ptr.wrapping_add(1);
 
-                            if ptr.align_offset(mem::align_of::<$id<i32>>()) == 0 {
+                            if ptr.align_offset(crate::mem::align_of::<$id<i32>>()) == 0 {
                                 // the pointer is properly aligned, so write_to_slice_aligned
                                 // won't fail here (e.g. this can happen for i128x1). So
                                 // we panic to make the "should_fail" test pass:
@@ -879,10 +879,10 @@ macro_rules! impl_minimal_p {
             }
         }
 
-        impl<T> ::hash::Hash for $id<T> {
+        impl<T> crate::hash::Hash for $id<T> {
             #[inline]
-            fn hash<H: ::hash::Hasher>(&self, state: &mut H) {
-                let s: $usize_ty = unsafe { mem::transmute(*self) };
+            fn hash<H: crate::hash::Hasher>(&self, state: &mut H) {
+                let s: $usize_ty = unsafe { crate::mem::transmute(*self) };
                 s.hash(state)
             }
         }
@@ -894,9 +894,9 @@ macro_rules! impl_minimal_p {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn hash() {
-                        use ::hash::{Hash, Hasher};
+                        use crate::hash::{Hash, Hasher};
                         #[allow(deprecated)]
-                        use ::hash::{SipHasher13};
+                        use crate::hash::{SipHasher13};
 
                         let values = [1_i32; $elem_count];
 
@@ -904,7 +904,7 @@ macro_rules! impl_minimal_p {
                         let mut array = [$id::<i32>::null().extract(0); $elem_count];
 
                         for i in 0..$elem_count {
-                            let ptr = unsafe { mem::transmute(&values[[i]] as *const i32) };
+                            let ptr = unsafe { crate::mem::transmute(&values[[i]] as *const i32) };
                             vec = vec.replace(i, ptr);
                             array[[i]] = ptr;
                         }
@@ -979,9 +979,9 @@ macro_rules! impl_minimal_p {
             #[inline]
             pub fn wrapping_offset(self, count: $isize_ty) -> Self {
                 unsafe {
-                    let x: $isize_ty = mem::transmute(self);
+                    let x: $isize_ty = crate::mem::transmute(self);
                     // note: {+,*} currently performs a `wrapping_{add, mul}`
-                    mem::transmute(x + (count * mem::size_of::<T>() as isize))
+                    crate::mem::transmute(x + (count * crate::mem::size_of::<T>() as isize))
                 }
             }
 
@@ -1046,10 +1046,10 @@ macro_rules! impl_minimal_p {
             /// different local variables.
             #[inline]
             pub fn wrapping_offset_from(self, origin: Self) -> $isize_ty {
-                let x: $isize_ty = unsafe { mem::transmute(self) };
-                let y: $isize_ty = unsafe { mem::transmute(origin) };
+                let x: $isize_ty = unsafe { crate::mem::transmute(self) };
+                let y: $isize_ty = unsafe { crate::mem::transmute(origin) };
                 // note: {-,/} currently perform wrapping_{sub, div}
-                (y - x) / (mem::size_of::<T>() as isize)
+                (y - x) / (crate::mem::size_of::<T>() as isize)
             }
 
             /// Calculates the offset from a pointer (convenience for

--- a/src/api/ops/scalar_arithmetic.rs
+++ b/src/api/ops/scalar_arithmetic.rs
@@ -2,14 +2,14 @@
 
 macro_rules! impl_ops_scalar_arithmetic {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::ops::Add<$elem_ty> for $id {
+        impl crate::ops::Add<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn add(self, other: $elem_ty) -> Self {
                 self + $id::splat(other)
             }
         }
-        impl ::ops::Add<$id> for $elem_ty {
+        impl crate::ops::Add<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn add(self, other: $id) -> $id {
@@ -17,14 +17,14 @@ macro_rules! impl_ops_scalar_arithmetic {
             }
         }
 
-        impl ::ops::Sub<$elem_ty> for $id {
+        impl crate::ops::Sub<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn sub(self, other: $elem_ty) -> Self {
                 self - $id::splat(other)
             }
         }
-        impl ::ops::Sub<$id> for $elem_ty {
+        impl crate::ops::Sub<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn sub(self, other: $id) -> $id {
@@ -32,14 +32,14 @@ macro_rules! impl_ops_scalar_arithmetic {
             }
         }
 
-        impl ::ops::Mul<$elem_ty> for $id {
+        impl crate::ops::Mul<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn mul(self, other: $elem_ty) -> Self {
                 self * $id::splat(other)
             }
         }
-        impl ::ops::Mul<$id> for $elem_ty {
+        impl crate::ops::Mul<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn mul(self, other: $id) -> $id {
@@ -47,14 +47,14 @@ macro_rules! impl_ops_scalar_arithmetic {
             }
         }
 
-        impl ::ops::Div<$elem_ty> for $id {
+        impl crate::ops::Div<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn div(self, other: $elem_ty) -> Self {
                 self / $id::splat(other)
             }
         }
-        impl ::ops::Div<$id> for $elem_ty {
+        impl crate::ops::Div<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn div(self, other: $id) -> $id {
@@ -62,14 +62,14 @@ macro_rules! impl_ops_scalar_arithmetic {
             }
         }
 
-        impl ::ops::Rem<$elem_ty> for $id {
+        impl crate::ops::Rem<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn rem(self, other: $elem_ty) -> Self {
                 self % $id::splat(other)
             }
         }
-        impl ::ops::Rem<$id> for $elem_ty {
+        impl crate::ops::Rem<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn rem(self, other: $id) -> $id {
@@ -77,35 +77,35 @@ macro_rules! impl_ops_scalar_arithmetic {
             }
         }
 
-        impl ::ops::AddAssign<$elem_ty> for $id {
+        impl crate::ops::AddAssign<$elem_ty> for $id {
             #[inline]
             fn add_assign(&mut self, other: $elem_ty) {
                 *self = *self + other;
             }
         }
 
-        impl ::ops::SubAssign<$elem_ty> for $id {
+        impl crate::ops::SubAssign<$elem_ty> for $id {
             #[inline]
             fn sub_assign(&mut self, other: $elem_ty) {
                 *self = *self - other;
             }
         }
 
-        impl ::ops::MulAssign<$elem_ty> for $id {
+        impl crate::ops::MulAssign<$elem_ty> for $id {
             #[inline]
             fn mul_assign(&mut self, other: $elem_ty) {
                 *self = *self * other;
             }
         }
 
-        impl ::ops::DivAssign<$elem_ty> for $id {
+        impl crate::ops::DivAssign<$elem_ty> for $id {
             #[inline]
             fn div_assign(&mut self, other: $elem_ty) {
                 *self = *self / other;
             }
         }
 
-        impl ::ops::RemAssign<$elem_ty> for $id {
+        impl crate::ops::RemAssign<$elem_ty> for $id {
             #[inline]
             fn rem_assign(&mut self, other: $elem_ty) {
                 *self = *self % other;

--- a/src/api/ops/scalar_bitwise.rs
+++ b/src/api/ops/scalar_bitwise.rs
@@ -6,14 +6,14 @@ macro_rules! impl_ops_scalar_bitwise {
         $id:ident | $test_tt:tt |
         ($true:expr, $false:expr)
     ) => {
-        impl ::ops::BitXor<$elem_ty> for $id {
+        impl crate::ops::BitXor<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: $elem_ty) -> Self {
                 self ^ $id::splat(other)
             }
         }
-        impl ::ops::BitXor<$id> for $elem_ty {
+        impl crate::ops::BitXor<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn bitxor(self, other: $id) -> $id {
@@ -21,14 +21,14 @@ macro_rules! impl_ops_scalar_bitwise {
             }
         }
 
-        impl ::ops::BitAnd<$elem_ty> for $id {
+        impl crate::ops::BitAnd<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn bitand(self, other: $elem_ty) -> Self {
                 self & $id::splat(other)
             }
         }
-        impl ::ops::BitAnd<$id> for $elem_ty {
+        impl crate::ops::BitAnd<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn bitand(self, other: $id) -> $id {
@@ -36,14 +36,14 @@ macro_rules! impl_ops_scalar_bitwise {
             }
         }
 
-        impl ::ops::BitOr<$elem_ty> for $id {
+        impl crate::ops::BitOr<$elem_ty> for $id {
             type Output = Self;
             #[inline]
             fn bitor(self, other: $elem_ty) -> Self {
                 self | $id::splat(other)
             }
         }
-        impl ::ops::BitOr<$id> for $elem_ty {
+        impl crate::ops::BitOr<$id> for $elem_ty {
             type Output = $id;
             #[inline]
             fn bitor(self, other: $id) -> $id {
@@ -51,19 +51,19 @@ macro_rules! impl_ops_scalar_bitwise {
             }
         }
 
-        impl ::ops::BitAndAssign<$elem_ty> for $id {
+        impl crate::ops::BitAndAssign<$elem_ty> for $id {
             #[inline]
             fn bitand_assign(&mut self, other: $elem_ty) {
                 *self = *self & other;
             }
         }
-        impl ::ops::BitOrAssign<$elem_ty> for $id {
+        impl crate::ops::BitOrAssign<$elem_ty> for $id {
             #[inline]
             fn bitor_assign(&mut self, other: $elem_ty) {
                 *self = *self | other;
             }
         }
-        impl ::ops::BitXorAssign<$elem_ty> for $id {
+        impl crate::ops::BitXorAssign<$elem_ty> for $id {
             #[inline]
             fn bitxor_assign(&mut self, other: $elem_ty) {
                 *self = *self ^ other;

--- a/src/api/ops/scalar_mask_bitwise.rs
+++ b/src/api/ops/scalar_mask_bitwise.rs
@@ -6,14 +6,14 @@ macro_rules! impl_ops_scalar_mask_bitwise {
         $id:ident | $test_tt:tt |
         ($true:expr, $false:expr)
     ) => {
-        impl ::ops::BitXor<bool> for $id {
+        impl crate::ops::BitXor<bool> for $id {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: bool) -> Self {
                 self ^ $id::splat(other)
             }
         }
-        impl ::ops::BitXor<$id> for bool {
+        impl crate::ops::BitXor<$id> for bool {
             type Output = $id;
             #[inline]
             fn bitxor(self, other: $id) -> $id {
@@ -21,14 +21,14 @@ macro_rules! impl_ops_scalar_mask_bitwise {
             }
         }
 
-        impl ::ops::BitAnd<bool> for $id {
+        impl crate::ops::BitAnd<bool> for $id {
             type Output = Self;
             #[inline]
             fn bitand(self, other: bool) -> Self {
                 self & $id::splat(other)
             }
         }
-        impl ::ops::BitAnd<$id> for bool {
+        impl crate::ops::BitAnd<$id> for bool {
             type Output = $id;
             #[inline]
             fn bitand(self, other: $id) -> $id {
@@ -36,14 +36,14 @@ macro_rules! impl_ops_scalar_mask_bitwise {
             }
         }
 
-        impl ::ops::BitOr<bool> for $id {
+        impl crate::ops::BitOr<bool> for $id {
             type Output = Self;
             #[inline]
             fn bitor(self, other: bool) -> Self {
                 self | $id::splat(other)
             }
         }
-        impl ::ops::BitOr<$id> for bool {
+        impl crate::ops::BitOr<$id> for bool {
             type Output = $id;
             #[inline]
             fn bitor(self, other: $id) -> $id {
@@ -51,19 +51,19 @@ macro_rules! impl_ops_scalar_mask_bitwise {
             }
         }
 
-        impl ::ops::BitAndAssign<bool> for $id {
+        impl crate::ops::BitAndAssign<bool> for $id {
             #[inline]
             fn bitand_assign(&mut self, other: bool) {
                 *self = *self & other;
             }
         }
-        impl ::ops::BitOrAssign<bool> for $id {
+        impl crate::ops::BitOrAssign<bool> for $id {
             #[inline]
             fn bitor_assign(&mut self, other: bool) {
                 *self = *self | other;
             }
         }
-        impl ::ops::BitXorAssign<bool> for $id {
+        impl crate::ops::BitXorAssign<bool> for $id {
             #[inline]
             fn bitxor_assign(&mut self, other: bool) {
                 *self = *self ^ other;

--- a/src/api/ops/scalar_shifts.rs
+++ b/src/api/ops/scalar_shifts.rs
@@ -2,14 +2,14 @@
 
 macro_rules! impl_ops_scalar_shifts {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::ops::Shl<u32> for $id {
+        impl crate::ops::Shl<u32> for $id {
             type Output = Self;
             #[inline]
             fn shl(self, other: u32) -> Self {
                 self << $id::splat(other as $elem_ty)
             }
         }
-        impl ::ops::Shr<u32> for $id {
+        impl crate::ops::Shr<u32> for $id {
             type Output = Self;
             #[inline]
             fn shr(self, other: u32) -> Self {
@@ -17,13 +17,13 @@ macro_rules! impl_ops_scalar_shifts {
             }
         }
 
-        impl ::ops::ShlAssign<u32> for $id {
+        impl crate::ops::ShlAssign<u32> for $id {
             #[inline]
             fn shl_assign(&mut self, other: u32) {
                 *self = *self << other;
             }
         }
-        impl ::ops::ShrAssign<u32> for $id {
+        impl crate::ops::ShrAssign<u32> for $id {
             #[inline]
             fn shr_assign(&mut self, other: u32) {
                 *self = *self >> other;

--- a/src/api/ops/vector_arithmetic.rs
+++ b/src/api/ops/vector_arithmetic.rs
@@ -2,80 +2,80 @@
 
 macro_rules! impl_ops_vector_arithmetic {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::ops::Add for $id {
+        impl crate::ops::Add for $id {
             type Output = Self;
             #[inline]
             fn add(self, other: Self) -> Self {
-                use llvm::simd_add;
+                use crate::llvm::simd_add;
                 unsafe { Simd(simd_add(self.0, other.0)) }
             }
         }
 
-        impl ::ops::Sub for $id {
+        impl crate::ops::Sub for $id {
             type Output = Self;
             #[inline]
             fn sub(self, other: Self) -> Self {
-                use llvm::simd_sub;
+                use crate::llvm::simd_sub;
                 unsafe { Simd(simd_sub(self.0, other.0)) }
             }
         }
 
-        impl ::ops::Mul for $id {
+        impl crate::ops::Mul for $id {
             type Output = Self;
             #[inline]
             fn mul(self, other: Self) -> Self {
-                use llvm::simd_mul;
+                use crate::llvm::simd_mul;
                 unsafe { Simd(simd_mul(self.0, other.0)) }
             }
         }
 
-        impl ::ops::Div for $id {
+        impl crate::ops::Div for $id {
             type Output = Self;
             #[inline]
             fn div(self, other: Self) -> Self {
-                use llvm::simd_div;
+                use crate::llvm::simd_div;
                 unsafe { Simd(simd_div(self.0, other.0)) }
             }
         }
 
-        impl ::ops::Rem for $id {
+        impl crate::ops::Rem for $id {
             type Output = Self;
             #[inline]
             fn rem(self, other: Self) -> Self {
-                use llvm::simd_rem;
+                use crate::llvm::simd_rem;
                 unsafe { Simd(simd_rem(self.0, other.0)) }
             }
         }
 
-        impl ::ops::AddAssign for $id {
+        impl crate::ops::AddAssign for $id {
             #[inline]
             fn add_assign(&mut self, other: Self) {
                 *self = *self + other;
             }
         }
 
-        impl ::ops::SubAssign for $id {
+        impl crate::ops::SubAssign for $id {
             #[inline]
             fn sub_assign(&mut self, other: Self) {
                 *self = *self - other;
             }
         }
 
-        impl ::ops::MulAssign for $id {
+        impl crate::ops::MulAssign for $id {
             #[inline]
             fn mul_assign(&mut self, other: Self) {
                 *self = *self * other;
             }
         }
 
-        impl ::ops::DivAssign for $id {
+        impl crate::ops::DivAssign for $id {
             #[inline]
             fn div_assign(&mut self, other: Self) {
                 *self = *self / other;
             }
         }
 
-        impl ::ops::RemAssign for $id {
+        impl crate::ops::RemAssign for $id {
             #[inline]
             fn rem_assign(&mut self, other: Self) {
                 *self = *self % other;

--- a/src/api/ops/vector_arithmetic.rs
+++ b/src/api/ops/vector_arithmetic.rs
@@ -6,7 +6,7 @@ macro_rules! impl_ops_vector_arithmetic {
             type Output = Self;
             #[inline]
             fn add(self, other: Self) -> Self {
-                use crate::llvm::simd_add;
+                use super::llvm::simd_add;
                 unsafe { Simd(simd_add(self.0, other.0)) }
             }
         }
@@ -15,7 +15,7 @@ macro_rules! impl_ops_vector_arithmetic {
             type Output = Self;
             #[inline]
             fn sub(self, other: Self) -> Self {
-                use crate::llvm::simd_sub;
+                use super::llvm::simd_sub;
                 unsafe { Simd(simd_sub(self.0, other.0)) }
             }
         }
@@ -24,7 +24,7 @@ macro_rules! impl_ops_vector_arithmetic {
             type Output = Self;
             #[inline]
             fn mul(self, other: Self) -> Self {
-                use crate::llvm::simd_mul;
+                use super::llvm::simd_mul;
                 unsafe { Simd(simd_mul(self.0, other.0)) }
             }
         }
@@ -33,7 +33,7 @@ macro_rules! impl_ops_vector_arithmetic {
             type Output = Self;
             #[inline]
             fn div(self, other: Self) -> Self {
-                use crate::llvm::simd_div;
+                use super::llvm::simd_div;
                 unsafe { Simd(simd_div(self.0, other.0)) }
             }
         }
@@ -42,7 +42,7 @@ macro_rules! impl_ops_vector_arithmetic {
             type Output = Self;
             #[inline]
             fn rem(self, other: Self) -> Self {
-                use crate::llvm::simd_rem;
+                use super::llvm::simd_rem;
                 unsafe { Simd(simd_rem(self.0, other.0)) }
             }
         }

--- a/src/api/ops/vector_bitwise.rs
+++ b/src/api/ops/vector_bitwise.rs
@@ -17,7 +17,7 @@ macro_rules! impl_ops_vector_bitwise {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: Self) -> Self {
-                use crate::llvm::simd_xor;
+                use super::llvm::simd_xor;
                 unsafe { Simd(simd_xor(self.0, other.0)) }
             }
         }
@@ -25,7 +25,7 @@ macro_rules! impl_ops_vector_bitwise {
             type Output = Self;
             #[inline]
             fn bitand(self, other: Self) -> Self {
-                use crate::llvm::simd_and;
+                use super::llvm::simd_and;
                 unsafe { Simd(simd_and(self.0, other.0)) }
             }
         }
@@ -33,7 +33,7 @@ macro_rules! impl_ops_vector_bitwise {
             type Output = Self;
             #[inline]
             fn bitor(self, other: Self) -> Self {
-                use crate::llvm::simd_or;
+                use super::llvm::simd_or;
                 unsafe { Simd(simd_or(self.0, other.0)) }
             }
         }

--- a/src/api/ops/vector_bitwise.rs
+++ b/src/api/ops/vector_bitwise.rs
@@ -6,50 +6,50 @@ macro_rules! impl_ops_vector_bitwise {
         $id:ident | $test_tt:tt |
         ($true:expr, $false:expr)
     ) => {
-        impl ::ops::Not for $id {
+        impl crate::ops::Not for $id {
             type Output = Self;
             #[inline]
             fn not(self) -> Self {
                 Self::splat($true) ^ self
             }
         }
-        impl ::ops::BitXor for $id {
+        impl crate::ops::BitXor for $id {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: Self) -> Self {
-                use llvm::simd_xor;
+                use crate::llvm::simd_xor;
                 unsafe { Simd(simd_xor(self.0, other.0)) }
             }
         }
-        impl ::ops::BitAnd for $id {
+        impl crate::ops::BitAnd for $id {
             type Output = Self;
             #[inline]
             fn bitand(self, other: Self) -> Self {
-                use llvm::simd_and;
+                use crate::llvm::simd_and;
                 unsafe { Simd(simd_and(self.0, other.0)) }
             }
         }
-        impl ::ops::BitOr for $id {
+        impl crate::ops::BitOr for $id {
             type Output = Self;
             #[inline]
             fn bitor(self, other: Self) -> Self {
-                use llvm::simd_or;
+                use crate::llvm::simd_or;
                 unsafe { Simd(simd_or(self.0, other.0)) }
             }
         }
-        impl ::ops::BitAndAssign for $id {
+        impl crate::ops::BitAndAssign for $id {
             #[inline]
             fn bitand_assign(&mut self, other: Self) {
                 *self = *self & other;
             }
         }
-        impl ::ops::BitOrAssign for $id {
+        impl crate::ops::BitOrAssign for $id {
             #[inline]
             fn bitor_assign(&mut self, other: Self) {
                 *self = *self | other;
             }
         }
-        impl ::ops::BitXorAssign for $id {
+        impl crate::ops::BitXorAssign for $id {
             #[inline]
             fn bitxor_assign(&mut self, other: Self) {
                 *self = *self ^ other;

--- a/src/api/ops/vector_float_min_max.rs
+++ b/src/api/ops/vector_float_min_max.rs
@@ -9,7 +9,7 @@ macro_rules! impl_ops_vector_float_min_max {
             /// the input vector lanes.
             #[inline]
             pub fn min(self, x: Self) -> Self {
-                use codegen::llvm::simd_fmin;
+                use crate::codegen::llvm::simd_fmin;
                 unsafe { Simd(simd_fmin(self.0, x.0)) }
             }
 
@@ -19,7 +19,7 @@ macro_rules! impl_ops_vector_float_min_max {
             /// the input vector lanes.
             #[inline]
             pub fn max(self, x: Self) -> Self {
-                use codegen::llvm::simd_fmax;
+                use crate::codegen::llvm::simd_fmax;
                 unsafe { Simd(simd_fmax(self.0, x.0)) }
             }
         }

--- a/src/api/ops/vector_float_min_max.rs
+++ b/src/api/ops/vector_float_min_max.rs
@@ -30,7 +30,7 @@ macro_rules! impl_ops_vector_float_min_max {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn min_max() {
-                        let n = $elem_ty::NAN;
+                        let n = crate::$elem_ty::NAN;
                         let o = $id::splat(1. as $elem_ty);
                         let t = $id::splat(2. as $elem_ty);
 

--- a/src/api/ops/vector_mask_bitwise.rs
+++ b/src/api/ops/vector_mask_bitwise.rs
@@ -17,7 +17,7 @@ macro_rules! impl_ops_vector_mask_bitwise {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: Self) -> Self {
-                use crate::llvm::simd_xor;
+                use super::llvm::simd_xor;
                 unsafe { Simd(simd_xor(self.0, other.0)) }
             }
         }
@@ -25,7 +25,7 @@ macro_rules! impl_ops_vector_mask_bitwise {
             type Output = Self;
             #[inline]
             fn bitand(self, other: Self) -> Self {
-                use crate::llvm::simd_and;
+                use super::llvm::simd_and;
                 unsafe { Simd(simd_and(self.0, other.0)) }
             }
         }
@@ -33,7 +33,7 @@ macro_rules! impl_ops_vector_mask_bitwise {
             type Output = Self;
             #[inline]
             fn bitor(self, other: Self) -> Self {
-                use crate::llvm::simd_or;
+                use super::llvm::simd_or;
                 unsafe { Simd(simd_or(self.0, other.0)) }
             }
         }

--- a/src/api/ops/vector_mask_bitwise.rs
+++ b/src/api/ops/vector_mask_bitwise.rs
@@ -6,50 +6,50 @@ macro_rules! impl_ops_vector_mask_bitwise {
         $id:ident | $test_tt:tt |
         ($true:expr, $false:expr)
     ) => {
-        impl ::ops::Not for $id {
+        impl crate::ops::Not for $id {
             type Output = Self;
             #[inline]
             fn not(self) -> Self {
                 Self::splat($true) ^ self
             }
         }
-        impl ::ops::BitXor for $id {
+        impl crate::ops::BitXor for $id {
             type Output = Self;
             #[inline]
             fn bitxor(self, other: Self) -> Self {
-                use llvm::simd_xor;
+                use crate::llvm::simd_xor;
                 unsafe { Simd(simd_xor(self.0, other.0)) }
             }
         }
-        impl ::ops::BitAnd for $id {
+        impl crate::ops::BitAnd for $id {
             type Output = Self;
             #[inline]
             fn bitand(self, other: Self) -> Self {
-                use llvm::simd_and;
+                use crate::llvm::simd_and;
                 unsafe { Simd(simd_and(self.0, other.0)) }
             }
         }
-        impl ::ops::BitOr for $id {
+        impl crate::ops::BitOr for $id {
             type Output = Self;
             #[inline]
             fn bitor(self, other: Self) -> Self {
-                use llvm::simd_or;
+                use crate::llvm::simd_or;
                 unsafe { Simd(simd_or(self.0, other.0)) }
             }
         }
-        impl ::ops::BitAndAssign for $id {
+        impl crate::ops::BitAndAssign for $id {
             #[inline]
             fn bitand_assign(&mut self, other: Self) {
                 *self = *self & other;
             }
         }
-        impl ::ops::BitOrAssign for $id {
+        impl crate::ops::BitOrAssign for $id {
             #[inline]
             fn bitor_assign(&mut self, other: Self) {
                 *self = *self | other;
             }
         }
-        impl ::ops::BitXorAssign for $id {
+        impl crate::ops::BitXorAssign for $id {
             #[inline]
             fn bitxor_assign(&mut self, other: Self) {
                 *self = *self ^ other;

--- a/src/api/ops/vector_neg.rs
+++ b/src/api/ops/vector_neg.rs
@@ -2,7 +2,7 @@
 
 macro_rules! impl_ops_vector_neg {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::ops::Neg for $id {
+        impl crate::ops::Neg for $id {
             type Output = Self;
             #[inline]
             fn neg(self) -> Self {

--- a/src/api/ops/vector_rotates.rs
+++ b/src/api/ops/vector_rotates.rs
@@ -13,7 +13,7 @@ macro_rules! impl_ops_vector_rotates {
             #[inline]
             pub fn rotate_left(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty =
-                    ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
+                    crate::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
                 (self << n) | (self >> ((LANE_WIDTH - n) % LANE_WIDTH))
@@ -28,7 +28,7 @@ macro_rules! impl_ops_vector_rotates {
             #[inline]
             pub fn rotate_right(self, n: $id) -> $id {
                 const LANE_WIDTH: $elem_ty =
-                    ::mem::size_of::<$elem_ty>() as $elem_ty * 8;
+                    crate::mem::size_of::<$elem_ty>() as $elem_ty * 8;
                 // Protect against undefined behavior for over-long bit shifts
                 let n = n % LANE_WIDTH;
                 (self >> n) | (self << ((LANE_WIDTH - n) % LANE_WIDTH))

--- a/src/api/ops/vector_shifts.rs
+++ b/src/api/ops/vector_shifts.rs
@@ -6,7 +6,7 @@ macro_rules! impl_ops_vector_shifts {
             type Output = Self;
             #[inline]
             fn shl(self, other: Self) -> Self {
-                use crate::llvm::simd_shl;
+                use super::llvm::simd_shl;
                 unsafe { Simd(simd_shl(self.0, other.0)) }
             }
         }
@@ -14,7 +14,7 @@ macro_rules! impl_ops_vector_shifts {
             type Output = Self;
             #[inline]
             fn shr(self, other: Self) -> Self {
-                use crate::llvm::simd_shr;
+                use super::llvm::simd_shr;
                 unsafe { Simd(simd_shr(self.0, other.0)) }
             }
         }

--- a/src/api/ops/vector_shifts.rs
+++ b/src/api/ops/vector_shifts.rs
@@ -2,29 +2,29 @@
 
 macro_rules! impl_ops_vector_shifts {
     ([$elem_ty:ident; $elem_count:expr]: $id:ident | $test_tt:tt) => {
-        impl ::ops::Shl<$id> for $id {
+        impl crate::ops::Shl<$id> for $id {
             type Output = Self;
             #[inline]
             fn shl(self, other: Self) -> Self {
-                use llvm::simd_shl;
+                use crate::llvm::simd_shl;
                 unsafe { Simd(simd_shl(self.0, other.0)) }
             }
         }
-        impl ::ops::Shr<$id> for $id {
+        impl crate::ops::Shr<$id> for $id {
             type Output = Self;
             #[inline]
             fn shr(self, other: Self) -> Self {
-                use llvm::simd_shr;
+                use crate::llvm::simd_shr;
                 unsafe { Simd(simd_shr(self.0, other.0)) }
             }
         }
-        impl ::ops::ShlAssign<$id> for $id {
+        impl crate::ops::ShlAssign<$id> for $id {
             #[inline]
             fn shl_assign(&mut self, other: Self) {
                 *self = *self << other;
             }
         }
-        impl ::ops::ShrAssign<$id> for $id {
+        impl crate::ops::ShrAssign<$id> for $id {
             #[inline]
             fn shr_assign(&mut self, other: Self) {
                 *self = *self >> other;

--- a/src/api/ptr/gather_scatter.rs
+++ b/src/api/ptr/gather_scatter.rs
@@ -154,7 +154,7 @@ macro_rules! impl_ptr_write {
                         let mut ptr = $id::<i32>::null();
                         for i in 0..$elem_count {
                             ptr = ptr.replace(i, unsafe {
-                                ::mem::transmute(arr.as_ptr().add(i))
+                                crate::mem::transmute(arr.as_ptr().add(i))
                             });
                         }
                         // ptr = [&arr[0], &arr[1], ...]

--- a/src/api/ptr/gather_scatter.rs
+++ b/src/api/ptr/gather_scatter.rs
@@ -45,7 +45,7 @@ macro_rules! impl_ptr_read {
 
                         for i in 0..$elem_count {
                             ptr = ptr.replace(i, unsafe {
-                                ::mem::transmute(&v[[i]] as *const i32)
+                                crate::mem::transmute(&v[[i]] as *const i32)
                             });
                         }
 

--- a/src/api/reductions/bitwise.rs
+++ b/src/api/reductions/bitwise.rs
@@ -17,7 +17,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn and(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use llvm::simd_reduce_and;
+                    use crate::llvm::simd_reduce_and;
                     let r: $ielem_ty = unsafe { simd_reduce_and(self.0) };
                     $convert(r)
                 }
@@ -41,7 +41,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn or(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use llvm::simd_reduce_or;
+                    use crate::llvm::simd_reduce_or;
                     let r: $ielem_ty = unsafe { simd_reduce_or(self.0) };
                     $convert(r)
                 }
@@ -65,7 +65,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn xor(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use llvm::simd_reduce_xor;
+                    use crate::llvm::simd_reduce_xor;
                     let r: $ielem_ty = unsafe { simd_reduce_xor(self.0) };
                     $convert(r)
                 }

--- a/src/api/reductions/bitwise.rs
+++ b/src/api/reductions/bitwise.rs
@@ -17,7 +17,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn and(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use crate::llvm::simd_reduce_and;
+                    use super::llvm::simd_reduce_and;
                     let r: $ielem_ty = unsafe { simd_reduce_and(self.0) };
                     $convert(r)
                 }
@@ -41,7 +41,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn or(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use crate::llvm::simd_reduce_or;
+                    use super::llvm::simd_reduce_or;
                     let r: $ielem_ty = unsafe { simd_reduce_or(self.0) };
                     $convert(r)
                 }
@@ -65,7 +65,7 @@ macro_rules! impl_reduction_bitwise {
             pub fn xor(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use crate::llvm::simd_reduce_xor;
+                    use super::llvm::simd_reduce_xor;
                     let r: $ielem_ty = unsafe { simd_reduce_xor(self.0) };
                     $convert(r)
                 }

--- a/src/api/reductions/float_arithmetic.rs
+++ b/src/api/reductions/float_arithmetic.rs
@@ -16,7 +16,7 @@ macro_rules! impl_reduction_float_arithmetic {
             #[inline]
             pub fn sum(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))] {
-                    use crate::llvm::simd_reduce_add_ordered;
+                    use super::llvm::simd_reduce_add_ordered;
                     unsafe { simd_reduce_add_ordered(self.0, 0 as $elem_ty) }
                 }
                 #[cfg(target_arch = "aarch64")] {
@@ -43,7 +43,7 @@ macro_rules! impl_reduction_float_arithmetic {
             #[inline]
             pub fn product(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))] {
-                    use crate::llvm::simd_reduce_mul_ordered;
+                    use super::llvm::simd_reduce_mul_ordered;
                     unsafe { simd_reduce_mul_ordered(self.0, 1 as $elem_ty) }
                 }
                 #[cfg(target_arch = "aarch64")] {
@@ -136,7 +136,7 @@ macro_rules! impl_reduction_float_arithmetic {
                         // https://github.com/rust-lang-nursery/packed_simd/issues/6
                         return;
 
-                        let n0 = $elem_ty::NAN;
+                        let n0 = crate::$elem_ty::NAN;
                         let v0 = $id::splat(-3.0);
                         for i in 0..$id::lanes() {
                             let mut v = v0.replace(i, n0);
@@ -164,7 +164,7 @@ macro_rules! impl_reduction_float_arithmetic {
                         // https://github.com/rust-lang-nursery/packed_simd/issues/6
                         return;
 
-                        let n0 = $elem_ty::NAN;
+                        let n0 = crate::$elem_ty::NAN;
                         let v0 = $id::splat(-3.0);
                         for i in 0..$id::lanes() {
                             let mut v = v0.replace(i, n0);
@@ -202,7 +202,7 @@ macro_rules! impl_reduction_float_arithmetic {
                             }
                         }
 
-                        let mut start = $elem_ty::EPSILON;
+                        let mut start = crate::$elem_ty::EPSILON;
                         let mut scalar_reduction = 0. as $elem_ty;
 
                         let mut v = $id::splat(0. as $elem_ty);
@@ -251,7 +251,7 @@ macro_rules! impl_reduction_float_arithmetic {
                             }
                         }
 
-                        let mut start = $elem_ty::EPSILON;
+                        let mut start = crate::$elem_ty::EPSILON;
                         let mut scalar_reduction = 1. as $elem_ty;
 
                         let mut v = $id::splat(0. as $elem_ty);

--- a/src/api/reductions/float_arithmetic.rs
+++ b/src/api/reductions/float_arithmetic.rs
@@ -16,7 +16,7 @@ macro_rules! impl_reduction_float_arithmetic {
             #[inline]
             pub fn sum(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))] {
-                    use llvm::simd_reduce_add_ordered;
+                    use crate::llvm::simd_reduce_add_ordered;
                     unsafe { simd_reduce_add_ordered(self.0, 0 as $elem_ty) }
                 }
                 #[cfg(target_arch = "aarch64")] {
@@ -43,7 +43,7 @@ macro_rules! impl_reduction_float_arithmetic {
             #[inline]
             pub fn product(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))] {
-                    use llvm::simd_reduce_mul_ordered;
+                    use crate::llvm::simd_reduce_mul_ordered;
                     unsafe { simd_reduce_mul_ordered(self.0, 1 as $elem_ty) }
                 }
                 #[cfg(target_arch = "aarch64")] {
@@ -58,31 +58,31 @@ macro_rules! impl_reduction_float_arithmetic {
             }
         }
 
-        impl ::iter::Sum for $id {
+        impl crate::iter::Sum for $id {
             #[inline]
             fn sum<I: Iterator<Item=$id>>(iter: I) -> $id {
-                iter.fold($id::splat(0.), ::ops::Add::add)
+                iter.fold($id::splat(0.), crate::ops::Add::add)
             }
         }
 
-        impl ::iter::Product for $id {
+        impl crate::iter::Product for $id {
             #[inline]
             fn product<I: Iterator<Item=$id>>(iter: I) -> $id {
-                iter.fold($id::splat(1.), ::ops::Mul::mul)
+                iter.fold($id::splat(1.), crate::ops::Mul::mul)
             }
         }
 
-        impl<'a> ::iter::Sum<&'a $id> for $id {
+        impl<'a> crate::iter::Sum<&'a $id> for $id {
             #[inline]
             fn sum<I: Iterator<Item=&'a $id>>(iter: I) -> $id {
-                iter.fold($id::splat(0.), |a, b| ::ops::Add::add(a, *b))
+                iter.fold($id::splat(0.), |a, b| crate::ops::Add::add(a, *b))
             }
         }
 
-        impl<'a> ::iter::Product<&'a $id> for $id {
+        impl<'a> crate::iter::Product<&'a $id> for $id {
             #[inline]
             fn product<I: Iterator<Item=&'a $id>>(iter: I) -> $id {
-                iter.fold($id::splat(1.), |a, b| ::ops::Mul::mul(a, *b))
+                iter.fold($id::splat(1.), |a, b| crate::ops::Mul::mul(a, *b))
             }
         }
 

--- a/src/api/reductions/integer_arithmetic.rs
+++ b/src/api/reductions/integer_arithmetic.rs
@@ -17,7 +17,7 @@ macro_rules! impl_reduction_integer_arithmetic {
             pub fn wrapping_sum(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use llvm::simd_reduce_add_ordered;
+                    use crate::llvm::simd_reduce_add_ordered;
                     let v: $ielem_ty = unsafe {
                         simd_reduce_add_ordered(self.0, 0 as $ielem_ty)
                     };
@@ -48,7 +48,7 @@ macro_rules! impl_reduction_integer_arithmetic {
             pub fn wrapping_product(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use llvm::simd_reduce_mul_ordered;
+                    use crate::llvm::simd_reduce_mul_ordered;
                     let v: $ielem_ty = unsafe {
                         simd_reduce_mul_ordered(self.0, 1 as $ielem_ty)
                     };
@@ -67,31 +67,31 @@ macro_rules! impl_reduction_integer_arithmetic {
             }
         }
 
-        impl ::iter::Sum for $id {
+        impl crate::iter::Sum for $id {
             #[inline]
             fn sum<I: Iterator<Item=$id>>(iter: I) -> $id {
-                iter.fold($id::splat(0), ::ops::Add::add)
+                iter.fold($id::splat(0), crate::ops::Add::add)
             }
         }
 
-        impl ::iter::Product for $id {
+        impl crate::iter::Product for $id {
             #[inline]
             fn product<I: Iterator<Item=$id>>(iter: I) -> $id {
-                iter.fold($id::splat(1), ::ops::Mul::mul)
+                iter.fold($id::splat(1), crate::ops::Mul::mul)
             }
         }
 
-        impl<'a> ::iter::Sum<&'a $id> for $id {
+        impl<'a> crate::iter::Sum<&'a $id> for $id {
             #[inline]
             fn sum<I: Iterator<Item=&'a $id>>(iter: I) -> $id {
-                iter.fold($id::splat(0), |a, b| ::ops::Add::add(a, *b))
+                iter.fold($id::splat(0), |a, b| crate::ops::Add::add(a, *b))
             }
         }
 
-        impl<'a> ::iter::Product<&'a $id> for $id {
+        impl<'a> crate::iter::Product<&'a $id> for $id {
             #[inline]
             fn product<I: Iterator<Item=&'a $id>>(iter: I) -> $id {
-                iter.fold($id::splat(1), |a, b| ::ops::Mul::mul(a, *b))
+                iter.fold($id::splat(1), |a, b| crate::ops::Mul::mul(a, *b))
             }
         }
 

--- a/src/api/reductions/integer_arithmetic.rs
+++ b/src/api/reductions/integer_arithmetic.rs
@@ -17,7 +17,7 @@ macro_rules! impl_reduction_integer_arithmetic {
             pub fn wrapping_sum(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use crate::llvm::simd_reduce_add_ordered;
+                    use super::llvm::simd_reduce_add_ordered;
                     let v: $ielem_ty = unsafe {
                         simd_reduce_add_ordered(self.0, 0 as $ielem_ty)
                     };
@@ -48,7 +48,7 @@ macro_rules! impl_reduction_integer_arithmetic {
             pub fn wrapping_product(self) -> $elem_ty {
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    use crate::llvm::simd_reduce_mul_ordered;
+                    use super::llvm::simd_reduce_mul_ordered;
                     let v: $ielem_ty = unsafe {
                         simd_reduce_mul_ordered(self.0, 1 as $ielem_ty)
                     };

--- a/src/api/reductions/min_max.rs
+++ b/src/api/reductions/min_max.rs
@@ -14,7 +14,7 @@ macro_rules! impl_reduction_min_max {
                     target_arch = "wasm32",
                 )))]
                 {
-                    use llvm::simd_reduce_max;
+                    use crate::llvm::simd_reduce_max;
                     let v: $ielem_ty = unsafe { simd_reduce_max(self.0) };
                     v as $elem_ty
                 }
@@ -48,7 +48,7 @@ macro_rules! impl_reduction_min_max {
                     target_arch = "wasm32",
                 ),))]
                 {
-                    use llvm::simd_reduce_min;
+                    use crate::llvm::simd_reduce_min;
                     let v: $ielem_ty = unsafe { simd_reduce_min(self.0) };
                     v as $elem_ty
                 }

--- a/src/api/reductions/min_max.rs
+++ b/src/api/reductions/min_max.rs
@@ -14,7 +14,7 @@ macro_rules! impl_reduction_min_max {
                     target_arch = "wasm32",
                 )))]
                 {
-                    use crate::llvm::simd_reduce_max;
+                    use super::llvm::simd_reduce_max;
                     let v: $ielem_ty = unsafe { simd_reduce_max(self.0) };
                     v as $elem_ty
                 }
@@ -48,7 +48,7 @@ macro_rules! impl_reduction_min_max {
                     target_arch = "wasm32",
                 ),))]
                 {
-                    use crate::llvm::simd_reduce_min;
+                    use super::llvm::simd_reduce_min;
                     let v: $ielem_ty = unsafe { simd_reduce_min(self.0) };
                     v as $elem_ty
                 }
@@ -126,7 +126,7 @@ macro_rules! test_reduction_float_min_max {
                     use super::*;
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn min_element_test() {
-                        let n = $elem_ty::NAN;
+                        let n = crate::$elem_ty::NAN;
 
                         assert_eq!(n.min(-3.), -3.);
                         assert_eq!((-3. as $elem_ty).min(n), -3.);
@@ -230,7 +230,7 @@ macro_rules! test_reduction_float_min_max {
                     }
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn max_element_test() {
-                        let n = $elem_ty::NAN;
+                        let n = crate::$elem_ty::NAN;
 
                         assert_eq!(n.max(-3.), -3.);
                         assert_eq!((-3. as $elem_ty).max(n), -3.);

--- a/src/api/select.rs
+++ b/src/api/select.rs
@@ -16,7 +16,7 @@ macro_rules! impl_select {
                     NT = <[$elem_ty; $elem_count] as sealed::SimdArray>::NT,
                 >,
             {
-                use crate::llvm::simd_select;
+                use super::llvm::simd_select;
                 Simd(unsafe { simd_select(self.0, a.0, b.0) })
             }
         }

--- a/src/api/select.rs
+++ b/src/api/select.rs
@@ -16,7 +16,7 @@ macro_rules! impl_select {
                     NT = <[$elem_ty; $elem_count] as sealed::SimdArray>::NT,
                 >,
             {
-                use llvm::simd_select;
+                use crate::llvm::simd_select;
                 Simd(unsafe { simd_select(self.0, a.0, b.0) })
             }
         }

--- a/src/api/slice/from_slice.rs
+++ b/src/api/slice/from_slice.rs
@@ -83,7 +83,7 @@ macro_rules! impl_slice_from_slice {
             interpolate_idents! {
                 pub mod [$id _slice_from_slice] {
                     use super::*;
-                    use iter::Iterator;
+                    use crate::iter::Iterator;
 
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn from_slice_unaligned() {

--- a/src/api/slice/from_slice.rs
+++ b/src/api/slice/from_slice.rs
@@ -15,7 +15,7 @@ macro_rules! impl_slice_from_slice {
                     assert!(slice.len() >= $elem_count);
                     let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
                     assert_eq!(
-                        target_ptr.align_offset(mem::align_of::<Self>()),
+                        target_ptr.align_offset(crate::mem::align_of::<Self>()),
                         0
                     );
                     Self::from_slice_aligned_unchecked(slice)
@@ -46,7 +46,7 @@ macro_rules! impl_slice_from_slice {
                 debug_assert!(slice.len() >= $elem_count);
                 let target_ptr = slice.get_unchecked(0) as *const $elem_ty;
                 debug_assert_eq!(
-                    target_ptr.align_offset(mem::align_of::<Self>()),
+                    target_ptr.align_offset(crate::mem::align_of::<Self>()),
                     0
                 );
 
@@ -63,13 +63,13 @@ macro_rules! impl_slice_from_slice {
             pub unsafe fn from_slice_unaligned_unchecked(
                 slice: &[$elem_ty],
             ) -> Self {
-                use mem::size_of;
+                use crate::mem::size_of;
                 debug_assert!(slice.len() >= $elem_count);
                 let target_ptr =
                     slice.get_unchecked(0) as *const $elem_ty as *const u8;
                 let mut x = Self::splat(0 as $elem_ty);
                 let self_ptr = &mut x as *mut Self as *mut u8;
-                ptr::copy_nonoverlapping(
+                crate::ptr::copy_nonoverlapping(
                     target_ptr,
                     self_ptr,
                     size_of::<Self>(),
@@ -170,7 +170,7 @@ macro_rules! impl_slice_from_slice {
                             // offset pointer by one element
                             let ptr = ptr.wrapping_add(1);
 
-                            if ptr.align_offset(mem::align_of::<$id>()) == 0 {
+                            if ptr.align_offset(crate::mem::align_of::<$id>()) == 0 {
                                 // the pointer is properly aligned, so from_slice_aligned
                                 // won't fail here (e.g. this can happen for i128x1). So
                                 // we panic to make the "should_fail" test pass:

--- a/src/api/slice/write_to_slice.rs
+++ b/src/api/slice/write_to_slice.rs
@@ -86,7 +86,7 @@ macro_rules! impl_slice_write_to_slice {
             interpolate_idents! {
                 pub mod [$id _slice_write_to_slice] {
                     use super::*;
-                    use iter::Iterator;
+                    use crate::iter::Iterator;
 
                     #[cfg_attr(not(target_arch = "wasm32"), test)] #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
                     fn write_to_slice_unaligned() {

--- a/src/api/slice/write_to_slice.rs
+++ b/src/api/slice/write_to_slice.rs
@@ -16,7 +16,7 @@ macro_rules! impl_slice_write_to_slice {
                     let target_ptr =
                         slice.get_unchecked_mut(0) as *mut $elem_ty;
                     assert_eq!(
-                        target_ptr.align_offset(mem::align_of::<Self>()),
+                        target_ptr.align_offset(crate::mem::align_of::<Self>()),
                         0
                     );
                     self.write_to_slice_aligned_unchecked(slice);
@@ -51,7 +51,7 @@ macro_rules! impl_slice_write_to_slice {
                 let target_ptr =
                     slice.get_unchecked_mut(0) as *mut $elem_ty;
                 debug_assert_eq!(
-                    target_ptr.align_offset(mem::align_of::<Self>()),
+                    target_ptr.align_offset(crate::mem::align_of::<Self>()),
                     0
                 );
 
@@ -72,10 +72,10 @@ macro_rules! impl_slice_write_to_slice {
                 let target_ptr =
                     slice.get_unchecked_mut(0) as *mut $elem_ty as *mut u8;
                 let self_ptr = &self as *const Self as *const u8;
-                ptr::copy_nonoverlapping(
+                crate::ptr::copy_nonoverlapping(
                     self_ptr,
                     target_ptr,
-                    mem::size_of::<Self>(),
+                    crate::mem::size_of::<Self>(),
                 );
             }
         }
@@ -167,7 +167,7 @@ macro_rules! impl_slice_write_to_slice {
                             // offset pointer by one element
                             let ptr = ptr.wrapping_add(1);
 
-                            if ptr.align_offset(mem::align_of::<$id>()) == 0 {
+                            if ptr.align_offset(crate::mem::align_of::<$id>()) == 0 {
                                 // the pointer is properly aligned, so write_to_slice_aligned
                                 // won't fail here (e.g. this can happen for i128x1). So
                                 // we panic to make the "should_fail" test pass:

--- a/src/api/swap_bytes.rs
+++ b/src/api/swap_bytes.rs
@@ -79,7 +79,7 @@ macro_rules! impl_swap_bytes {
                         ($func: ident) => {{
                             let actual = swap!($func);
                             let expected =
-                                BYTES.iter().rev().skip(64 - mem::size_of::<$id>());
+                                BYTES.iter().rev().skip(64 - crate::mem::size_of::<$id>());
 
                             assert!(actual.iter().zip(expected).all(|(x, y)| x == y));
                         }};

--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -1,9 +1,9 @@
 //! LLVM's platform intrinsics
 #![allow(dead_code)]
 
-use sealed::Shuffle;
+use crate::sealed::Shuffle;
 #[allow(unused_imports)] // FIXME: spurious warning?
-use sealed::Simd;
+use crate::sealed::Simd;
 
 // Shuffle intrinsics: expanded in users' crates, therefore public.
 extern "platform-intrinsic" {

--- a/src/codegen/math/float/abs.rs
+++ b/src/codegen/math/float/abs.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: fabs_f64);
         impl_unary!(f64x8[f64; 8]: fabs_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_fabsf4_avx2128);

--- a/src/codegen/math/float/abs.rs
+++ b/src/codegen/math/float/abs.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: fabs_f64);
         impl_unary!(f64x8[f64; 8]: fabs_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_fabsf4_avx2128);

--- a/src/codegen/math/float/cos.rs
+++ b/src/codegen/math/float/cos.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: cos_f64);
         impl_unary!(f64x8[f64; 8]: cos_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_cosf4_u10avx2128);

--- a/src/codegen/math/float/cos.rs
+++ b/src/codegen/math/float/cos.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: cos_f64);
         impl_unary!(f64x8[f64; 8]: cos_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_cosf4_u10avx2128);

--- a/src/codegen/math/float/cos_pi.rs
+++ b/src/codegen/math/float/cos_pi.rs
@@ -34,7 +34,7 @@ macro_rules! impl_def64 {
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_cospif4_u05avx2128);

--- a/src/codegen/math/float/cos_pi.rs
+++ b/src/codegen/math/float/cos_pi.rs
@@ -23,18 +23,18 @@ macro_rules! impl_def {
 }
 macro_rules! impl_def32 {
     ($vid:ident) => {
-        impl_def!($vid, core::f32::consts::PI);
+        impl_def!($vid, crate::f32::consts::PI);
     };
 }
 macro_rules! impl_def64 {
     ($vid:ident) => {
-        impl_def!($vid, core::f64::consts::PI);
+        impl_def!($vid, crate::f64::consts::PI);
     };
 }
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_cospif4_u05avx2128);

--- a/src/codegen/math/float/exp.rs
+++ b/src/codegen/math/float/exp.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: exp_f64);
         impl_unary!(f64x8[f64; 8]: exp_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_expf4_u10avx2128);

--- a/src/codegen/math/float/exp.rs
+++ b/src/codegen/math/float/exp.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: exp_f64);
         impl_unary!(f64x8[f64; 8]: exp_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_expf4_u10avx2128);

--- a/src/codegen/math/float/ln.rs
+++ b/src/codegen/math/float/ln.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: ln_f64);
         impl_unary!(f64x8[f64; 8]: ln_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_logf4_u10avx2128);

--- a/src/codegen/math/float/ln.rs
+++ b/src/codegen/math/float/ln.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: ln_f64);
         impl_unary!(f64x8[f64; 8]: ln_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_logf4_u10avx2128);

--- a/src/codegen/math/float/macros.rs
+++ b/src/codegen/math/float/macros.rs
@@ -9,7 +9,7 @@ macro_rules! impl_unary_ {
             #[inline]
             fn $trait_method(self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     transmute($fun(transmute(self)))
                 }
             }
@@ -22,7 +22,7 @@ macro_rules! impl_unary_ {
             #[inline]
             fn $trait_method(self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     transmute($fun(self.0))
                 }
             }
@@ -53,7 +53,7 @@ macro_rules! impl_unary_ {
             #[inline]
             fn $trait_method(self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         halves: [$vech_id; 2],
@@ -77,7 +77,7 @@ macro_rules! impl_unary_ {
             #[inline]
             fn $trait_method(self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         quarters: [$vecq_id; 4],
@@ -105,7 +105,7 @@ macro_rules! impl_unary_ {
             #[inline]
             fn $trait_method(self) -> Self {
                 unsafe {
-                    use mem::{transmute, uninitialized};
+                    use crate::mem::{transmute, uninitialized};
 
                     union U {
                         vec: [$vec_id; 2],
@@ -181,7 +181,7 @@ macro_rules! impl_tertiary_ {
             #[inline]
             fn $trait_method(self, y: Self, z: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     transmute($fun(
                         transmute(self),
                         transmute(y),
@@ -218,7 +218,7 @@ macro_rules! impl_tertiary_ {
             #[inline]
             fn $trait_method(self, y: Self, z: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         halves: [$vech_id; 2],
@@ -250,7 +250,7 @@ macro_rules! impl_tertiary_ {
             #[inline]
             fn $trait_method(self, y: Self, z: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         quarters: [$vecq_id; 4],
@@ -295,7 +295,7 @@ macro_rules! impl_tertiary_ {
             #[inline]
             fn $trait_method(self, y: Self, z: Self) -> Self {
                 unsafe {
-                    use mem::{transmute, uninitialized};
+                    use crate::mem::{transmute, uninitialized};
 
                     union U {
                         vec: [$vec_id; 2],
@@ -374,7 +374,7 @@ macro_rules! impl_binary_ {
             #[inline]
             fn $trait_method(self, y: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     transmute($fun(transmute(self), transmute(y)))
                 }
             }
@@ -406,7 +406,7 @@ macro_rules! impl_binary_ {
             #[inline]
             fn $trait_method(self, y: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         halves: [$vech_id; 2],
@@ -435,7 +435,7 @@ macro_rules! impl_binary_ {
             #[inline]
             fn $trait_method(self, y: Self) -> Self {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     union U {
                         vec: $vec_id,
                         quarters: [$vecq_id; 4],
@@ -475,7 +475,7 @@ macro_rules! impl_binary_ {
             #[inline]
             fn $trait_method(self, y: Self) -> Self {
                 unsafe {
-                    use mem::{transmute, uninitialized};
+                    use crate::mem::{transmute, uninitialized};
 
                     union U {
                         vec: [$vec_id; 2],

--- a/src/codegen/math/float/mul_add.rs
+++ b/src/codegen/math/float/mul_add.rs
@@ -56,7 +56,7 @@ cfg_if! {
         impl_broken!(f64x4);
         impl_broken!(f64x8);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_tertiary!(f32x2[t => f32x4]: Sleef_fmaf4_avx2128);

--- a/src/codegen/math/float/mul_add.rs
+++ b/src/codegen/math/float/mul_add.rs
@@ -56,7 +56,7 @@ cfg_if! {
         impl_broken!(f64x4);
         impl_broken!(f64x8);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_tertiary!(f32x2[t => f32x4]: Sleef_fmaf4_avx2128);

--- a/src/codegen/math/float/mul_adde.rs
+++ b/src/codegen/math/float/mul_adde.rs
@@ -39,10 +39,10 @@ macro_rules! impl_mul_adde {
                 #[cfg(not(target_arch = "s390x"))]
                 {
                     unsafe {
-                        mem::transmute($fn(
-                            mem::transmute(self),
-                            mem::transmute(y),
-                            mem::transmute(z),
+                        crate::mem::transmute($fn(
+                            crate::mem::transmute(self),
+                            crate::mem::transmute(y),
+                            crate::mem::transmute(z),
                         ))
                     }
                 }

--- a/src/codegen/math/float/powf.rs
+++ b/src/codegen/math/float/powf.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_binary!(f64x4[f64; 4]: powf_f64);
         impl_binary!(f64x8[f64; 8]: powf_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_binary!(f32x2[t => f32x4]: Sleef_powf4_u10avx2128);

--- a/src/codegen/math/float/powf.rs
+++ b/src/codegen/math/float/powf.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_binary!(f64x4[f64; 4]: powf_f64);
         impl_binary!(f64x8[f64; 8]: powf_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_binary!(f32x2[t => f32x4]: Sleef_powf4_u10avx2128);

--- a/src/codegen/math/float/sin.rs
+++ b/src/codegen/math/float/sin.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: sin_f64);
         impl_unary!(f64x8[f64; 8]: sin_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sinf4_u10avx2128);

--- a/src/codegen/math/float/sin.rs
+++ b/src/codegen/math/float/sin.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: sin_f64);
         impl_unary!(f64x8[f64; 8]: sin_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sinf4_u10avx2128);

--- a/src/codegen/math/float/sin_cos_pi.rs
+++ b/src/codegen/math/float/sin_cos_pi.rs
@@ -25,12 +25,12 @@ macro_rules! impl_def {
 
 macro_rules! impl_def32 {
     ($vid:ident) => {
-        impl_def!($vid, core::f32::consts::PI);
+        impl_def!($vid, crate::f32::consts::PI);
     };
 }
 macro_rules! impl_def64 {
     ($vid:ident) => {
-        impl_def!($vid, core::f64::consts::PI);
+        impl_def!($vid, crate::f64::consts::PI);
     };
 }
 
@@ -40,7 +40,7 @@ macro_rules! impl_unary_t {
             type Output = (Self, Self);
             fn sin_cos_pi(self) -> Self::Output {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
                     transmute($fun(transmute(self)))
                 }
             }
@@ -51,7 +51,7 @@ macro_rules! impl_unary_t {
             type Output = (Self, Self);
             fn sin_cos_pi(self) -> Self::Output {
                 unsafe {
-                    use mem::{transmute, uninitialized};
+                    use crate::mem::{transmute, uninitialized};
 
                     union U {
                         vec: [$vid; 2],
@@ -76,7 +76,7 @@ macro_rules! impl_unary_t {
             type Output = (Self, Self);
             fn sin_cos_pi(self) -> Self::Output {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
 
                     union U {
                         vec: $vid,
@@ -105,7 +105,7 @@ macro_rules! impl_unary_t {
             type Output = (Self, Self);
             fn sin_cos_pi(self) -> Self::Output {
                 unsafe {
-                    use mem::transmute;
+                    use crate::mem::transmute;
 
                     union U {
                         vec: $vid,
@@ -141,7 +141,7 @@ macro_rules! impl_unary_t {
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary_t!(f32x2[t => f32x4]: Sleef_sincospif4_u05avx2128);

--- a/src/codegen/math/float/sin_cos_pi.rs
+++ b/src/codegen/math/float/sin_cos_pi.rs
@@ -141,7 +141,7 @@ macro_rules! impl_unary_t {
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary_t!(f32x2[t => f32x4]: Sleef_sincospif4_u05avx2128);

--- a/src/codegen/math/float/sin_pi.rs
+++ b/src/codegen/math/float/sin_pi.rs
@@ -23,18 +23,18 @@ macro_rules! impl_def {
 }
 macro_rules! impl_def32 {
     ($vid:ident) => {
-        impl_def!($vid, core::f32::consts::PI);
+        impl_def!($vid, crate::f32::consts::PI);
     };
 }
 macro_rules! impl_def64 {
     ($vid:ident) => {
-        impl_def!($vid, core::f64::consts::PI);
+        impl_def!($vid, crate::f64::consts::PI);
     };
 }
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sinpif4_u05avx2128);

--- a/src/codegen/math/float/sin_pi.rs
+++ b/src/codegen/math/float/sin_pi.rs
@@ -34,7 +34,7 @@ macro_rules! impl_def64 {
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sinpif4_u05avx2128);

--- a/src/codegen/math/float/sqrt.rs
+++ b/src/codegen/math/float/sqrt.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: sqrt_f64);
         impl_unary!(f64x8[f64; 8]: sqrt_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sqrtf4_avx2128);

--- a/src/codegen/math/float/sqrt.rs
+++ b/src/codegen/math/float/sqrt.rs
@@ -50,7 +50,7 @@ cfg_if! {
         impl_unary!(f64x4[f64; 4]: sqrt_f64);
         impl_unary!(f64x8[f64; 8]: sqrt_f64);
     } else if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sqrtf4_avx2128);

--- a/src/codegen/math/float/sqrte.rs
+++ b/src/codegen/math/float/sqrte.rs
@@ -1,10 +1,9 @@
 //! Vertical floating-point `sqrt`
 #![allow(unused)]
 
-use crate::llvm::simd_fsqrt;
-
 // FIXME 64-bit 1 elem vectors sqrte
 
+use super::super::super::llvm::simd_fsqrt;
 use crate::*;
 
 crate trait Sqrte {
@@ -15,7 +14,7 @@ gen_unary_impl_table!(Sqrte, sqrte);
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use crate::sleef_sys::*;
+        use sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sqrtf4_u35avx2128);

--- a/src/codegen/math/float/sqrte.rs
+++ b/src/codegen/math/float/sqrte.rs
@@ -1,7 +1,7 @@
 //! Vertical floating-point `sqrt`
 #![allow(unused)]
 
-use llvm::simd_fsqrt;
+use crate::llvm::simd_fsqrt;
 
 // FIXME 64-bit 1 elem vectors sqrte
 
@@ -15,7 +15,7 @@ gen_unary_impl_table!(Sqrte, sqrte);
 
 cfg_if! {
     if #[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))] {
-        use ::sleef_sys::*;
+        use crate::sleef_sys::*;
         cfg_if! {
             if #[cfg(target_feature = "avx2")] {
                 impl_unary!(f32x2[t => f32x4]: Sleef_sqrtf4_u35avx2128);

--- a/src/codegen/pointer_sized_int.rs
+++ b/src/codegen/pointer_sized_int.rs
@@ -1,5 +1,7 @@
 //! Provides `isize` and `usize`
 
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(target_pointer_width = "8")] {
         crate type isize_ = i8;

--- a/src/codegen/reductions/mask/aarch64.rs
+++ b/src/codegen/reductions/mask/aarch64.rs
@@ -8,7 +8,7 @@ macro_rules! aarch64_128_neon_impl {
             #[target_feature(enable = "neon")]
             unsafe fn all(self) -> bool {
                 use crate::arch::aarch64::$vmin;
-                $vmin(::mem::transmute(self)) != 0
+                $vmin(crate::mem::transmute(self)) != 0
             }
         }
         impl Any for $id {
@@ -16,7 +16,7 @@ macro_rules! aarch64_128_neon_impl {
             #[target_feature(enable = "neon")]
             unsafe fn any(self) -> bool {
                 use crate::arch::aarch64::$vmax;
-                $vmax(::mem::transmute(self)) != 0
+                $vmax(crate::mem::transmute(self)) != 0
             }
         }
     }

--- a/src/codegen/reductions/mask/aarch64.rs
+++ b/src/codegen/reductions/mask/aarch64.rs
@@ -7,7 +7,7 @@ macro_rules! aarch64_128_neon_impl {
             #[inline]
             #[target_feature(enable = "neon")]
             unsafe fn all(self) -> bool {
-                use ::arch::aarch64::$vmin;
+                use crate::arch::aarch64::$vmin;
                 $vmin(::mem::transmute(self)) != 0
             }
         }
@@ -15,7 +15,7 @@ macro_rules! aarch64_128_neon_impl {
             #[inline]
             #[target_feature(enable = "neon")]
             unsafe fn any(self) -> bool {
-                use ::arch::aarch64::$vmax;
+                use crate::arch::aarch64::$vmax;
                 $vmax(::mem::transmute(self)) != 0
             }
         }

--- a/src/codegen/reductions/mask/arm.rs
+++ b/src/codegen/reductions/mask/arm.rs
@@ -7,11 +7,11 @@ macro_rules! arm_m32x2_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
-                use arch::arm::$vpmin;
+                use crate::arch::arm::$vpmin;
                 use crate::mem::transmute;
                 // pmin((a, b), (-,-)) => (b, -).0 => b
                 let tmp: $id =
-                    transmute($vpmin(transmute(self), ::mem::uninitialized()));
+                    transmute($vpmin(transmute(self), crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -19,11 +19,11 @@ macro_rules! arm_m32x2_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
-                use arch::arm::$vpmax;
+                use crate::arch::arm::$vpmax;
                 use crate::mem::transmute;
                 // pmax((a, b), (-,-)) => (b, -).0 => b
                 let tmp: $id =
-                    transmute($vpmax(transmute(self), ::mem::uninitialized()));
+                    transmute($vpmax(transmute(self), crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -37,12 +37,12 @@ macro_rules! arm_m16x4_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
-                use arch::arm::$vpmin;
+                use crate::arch::arm::$vpmin;
                 use crate::mem::transmute;
                 // tmp = pmin((a, b, c, d), (-,-,-,-)) => (a, c, -, -)
-                let tmp = $vpmin(transmute(self), ::mem::uninitialized());
+                let tmp = $vpmin(transmute(self), crate::mem::uninitialized());
                 // tmp = pmin((a, b, -, -), (-,-,-,-)) => (c, -, -, -).0 => c
-                let tmp: $id = transmute($vpmin(tmp, ::mem::uninitialized()));
+                let tmp: $id = transmute($vpmin(tmp, crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -50,12 +50,12 @@ macro_rules! arm_m16x4_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
-                use arch::arm::$vpmax;
+                use crate::arch::arm::$vpmax;
                 use crate::mem::transmute;
                 // tmp = pmax((a, b, c, d), (-,-,-,-)) => (a, c, -, -)
-                let tmp = $vpmax(transmute(self), ::mem::uninitialized());
+                let tmp = $vpmax(transmute(self), crate::mem::uninitialized());
                 // tmp = pmax((a, b, -, -), (-,-,-,-)) => (c, -, -, -).0 => c
-                let tmp: $id = transmute($vpmax(tmp, ::mem::uninitialized()));
+                let tmp: $id = transmute($vpmax(tmp, crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -69,23 +69,23 @@ macro_rules! arm_m8x8_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
-                use arch::arm::$vpmin;
+                use crate::arch::arm::$vpmin;
                 use crate::mem::transmute;
                 // tmp = pmin(
                 //     (a, b, c, d, e, f, g, h),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (a, c, e, g, -, -, -, -)
-                let tmp = $vpmin(transmute(self), ::mem::uninitialized());
+                let tmp = $vpmin(transmute(self), crate::mem::uninitialized());
                 // tmp = pmin(
                 //     (a, c, e, g, -, -, -, -),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (c, g, -, -, -, -, -, -)
-                let tmp = $vpmin(tmp, ::mem::uninitialized());
+                let tmp = $vpmin(tmp, crate::mem::uninitialized());
                 // tmp = pmin(
                 //     (c, g, -, -, -, -, -, -),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (g, -, -, -, -, -, -, -).0 => g
-                let tmp: $id = transmute($vpmin(tmp, ::mem::uninitialized()));
+                let tmp: $id = transmute($vpmin(tmp, crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -93,23 +93,23 @@ macro_rules! arm_m8x8_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
-                use arch::arm::$vpmax;
+                use crate::arch::arm::$vpmax;
                 use crate::mem::transmute;
                 // tmp = pmax(
                 //     (a, b, c, d, e, f, g, h),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (a, c, e, g, -, -, -, -)
-                let tmp = $vpmax(transmute(self), ::mem::uninitialized());
+                let tmp = $vpmax(transmute(self), crate::mem::uninitialized());
                 // tmp = pmax(
                 //     (a, c, e, g, -, -, -, -),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (c, g, -, -, -, -, -, -)
-                let tmp = $vpmax(tmp, ::mem::uninitialized());
+                let tmp = $vpmax(tmp, crate::mem::uninitialized());
                 // tmp = pmax(
                 //     (c, g, -, -, -, -, -, -),
                 //     (-, -, -, -, -, -, -, -)
                 // ) => (g, -, -, -, -, -, -, -).0 => g
-                let tmp: $id = transmute($vpmax(tmp, ::mem::uninitialized()));
+                let tmp: $id = transmute($vpmax(tmp, crate::mem::uninitialized()));
                 tmp.extract(0)
             }
         }
@@ -124,7 +124,7 @@ macro_rules! arm_128_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
-                use arch::arm::$vpmin;
+                use crate::arch::arm::$vpmin;
                 use crate::mem::transmute;
                 union U {
                     halves: ($half, $half),
@@ -142,7 +142,7 @@ macro_rules! arm_128_v7_neon_impl {
             #[inline]
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
-                use arch::arm::$vpmax;
+                use crate::arch::arm::$vpmax;
                 use crate::mem::transmute;
                 union U {
                     halves: ($half, $half),

--- a/src/codegen/reductions/mask/arm.rs
+++ b/src/codegen/reductions/mask/arm.rs
@@ -8,7 +8,7 @@ macro_rules! arm_m32x2_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
                 use arch::arm::$vpmin;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // pmin((a, b), (-,-)) => (b, -).0 => b
                 let tmp: $id =
                     transmute($vpmin(transmute(self), ::mem::uninitialized()));
@@ -20,7 +20,7 @@ macro_rules! arm_m32x2_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
                 use arch::arm::$vpmax;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // pmax((a, b), (-,-)) => (b, -).0 => b
                 let tmp: $id =
                     transmute($vpmax(transmute(self), ::mem::uninitialized()));
@@ -38,7 +38,7 @@ macro_rules! arm_m16x4_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
                 use arch::arm::$vpmin;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // tmp = pmin((a, b, c, d), (-,-,-,-)) => (a, c, -, -)
                 let tmp = $vpmin(transmute(self), ::mem::uninitialized());
                 // tmp = pmin((a, b, -, -), (-,-,-,-)) => (c, -, -, -).0 => c
@@ -51,7 +51,7 @@ macro_rules! arm_m16x4_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
                 use arch::arm::$vpmax;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // tmp = pmax((a, b, c, d), (-,-,-,-)) => (a, c, -, -)
                 let tmp = $vpmax(transmute(self), ::mem::uninitialized());
                 // tmp = pmax((a, b, -, -), (-,-,-,-)) => (c, -, -, -).0 => c
@@ -70,7 +70,7 @@ macro_rules! arm_m8x8_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
                 use arch::arm::$vpmin;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // tmp = pmin(
                 //     (a, b, c, d, e, f, g, h),
                 //     (-, -, -, -, -, -, -, -)
@@ -94,7 +94,7 @@ macro_rules! arm_m8x8_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
                 use arch::arm::$vpmax;
-                use mem::transmute;
+                use crate::mem::transmute;
                 // tmp = pmax(
                 //     (a, b, c, d, e, f, g, h),
                 //     (-, -, -, -, -, -, -, -)
@@ -125,7 +125,7 @@ macro_rules! arm_128_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn all(self) -> bool {
                 use arch::arm::$vpmin;
-                use mem::transmute;
+                use crate::mem::transmute;
                 union U {
                     halves: ($half, $half),
                     vec: $id,
@@ -143,7 +143,7 @@ macro_rules! arm_128_v7_neon_impl {
             #[target_feature(enable = "v7,neon")]
             unsafe fn any(self) -> bool {
                 use arch::arm::$vpmax;
-                use mem::transmute;
+                use crate::mem::transmute;
                 union U {
                     halves: ($half, $half),
                     vec: $id,

--- a/src/codegen/reductions/mask/fallback_impl.rs
+++ b/src/codegen/reductions/mask/fallback_impl.rs
@@ -5,14 +5,14 @@ macro_rules! fallback_to_other_impl {
         impl All for $id {
             #[inline]
             unsafe fn all(self) -> bool {
-                let m: $other = mem::transmute(self);
+                let m: $other = crate::mem::transmute(self);
                 m.all()
             }
         }
         impl Any for $id {
             #[inline]
             unsafe fn any(self) -> bool {
-                let m: $other = mem::transmute(self);
+                let m: $other = crate::mem::transmute(self);
                 m.any()
             }
         }
@@ -26,14 +26,14 @@ macro_rules! fallback_impl {
         impl All for m8x2 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: u16 = mem::transmute(self);
+                let i: u16 = crate::mem::transmute(self);
                 i == u16::max_value()
             }
         }
         impl Any for m8x2 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: u16 = mem::transmute(self);
+                let i: u16 = crate::mem::transmute(self);
                 i != 0
             }
         }
@@ -43,14 +43,14 @@ macro_rules! fallback_impl {
         impl All for m8x4 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: u32 = mem::transmute(self);
+                let i: u32 = crate::mem::transmute(self);
                 i == u32::max_value()
             }
         }
         impl Any for m8x4 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: u32 = mem::transmute(self);
+                let i: u32 = crate::mem::transmute(self);
                 i != 0
             }
         }
@@ -63,14 +63,14 @@ macro_rules! fallback_impl {
         impl All for m8x8 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: u64 = mem::transmute(self);
+                let i: u64 = crate::mem::transmute(self);
                 i == u64::max_value()
             }
         }
         impl Any for m8x8 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: u64 = mem::transmute(self);
+                let i: u64 = crate::mem::transmute(self);
                 i != 0
             }
         }
@@ -87,14 +87,14 @@ macro_rules! fallback_impl {
         impl All for m8x16 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: u128 = mem::transmute(self);
+                let i: u128 = crate::mem::transmute(self);
                 i == u128::max_value()
             }
         }
         impl Any for m8x16 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: u128 = mem::transmute(self);
+                let i: u128 = crate::mem::transmute(self);
                 i != 0
             }
         }
@@ -116,7 +116,7 @@ macro_rules! fallback_impl {
         impl All for m8x32 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: [u128; 2] = mem::transmute(self);
+                let i: [u128; 2] = crate::mem::transmute(self);
                 let o: [u128; 2] = [u128::max_value(); 2];
                 i == o
             }
@@ -124,7 +124,7 @@ macro_rules! fallback_impl {
         impl Any for m8x32 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: [u128; 2] = mem::transmute(self);
+                let i: [u128; 2] = crate::mem::transmute(self);
                 let o: [u128; 2] = [0; 2];
                 i != o
             }
@@ -147,7 +147,7 @@ macro_rules! fallback_impl {
         impl All for m8x64 {
             #[inline]
             unsafe fn all(self) -> bool {
-                let i: [u128; 4] = mem::transmute(self);
+                let i: [u128; 4] = crate::mem::transmute(self);
                 let o: [u128; 4] = [u128::max_value(); 4];
                 i == o
             }
@@ -155,7 +155,7 @@ macro_rules! fallback_impl {
         impl Any for m8x64 {
             #[inline]
             unsafe fn any(self) -> bool {
-                let i: [u128; 4] = mem::transmute(self);
+                let i: [u128; 4] = crate::mem::transmute(self);
                 let o: [u128; 4] = [0; 4];
                 i != o
             }

--- a/src/codegen/reductions/mask/x86.rs
+++ b/src/codegen/reductions/mask/x86.rs
@@ -127,14 +127,14 @@ macro_rules! x86_intr_impl {
     impl All for $id {
         #[inline]
         unsafe fn all(self) -> bool {
-        use crate::llvm::simd_reduce_all;
+        use super::super::super::llvm::simd_reduce_all;
             simd_reduce_all(self.0)
         }
     }
         impl Any for $id {
             #[inline]
             unsafe fn any(self) -> bool {
-            use crate::llvm::simd_reduce_any;
+            use super::super::super::llvm::simd_reduce_any;
                 simd_reduce_any(self.0)
             }
         }

--- a/src/codegen/reductions/mask/x86.rs
+++ b/src/codegen/reductions/mask/x86.rs
@@ -127,14 +127,14 @@ macro_rules! x86_intr_impl {
     impl All for $id {
         #[inline]
         unsafe fn all(self) -> bool {
-        use llvm::simd_reduce_all;
+        use crate::llvm::simd_reduce_all;
             simd_reduce_all(self.0)
         }
     }
         impl Any for $id {
             #[inline]
             unsafe fn any(self) -> bool {
-            use llvm::simd_reduce_any;
+            use crate::llvm::simd_reduce_any;
                 simd_reduce_any(self.0)
             }
         }

--- a/src/codegen/reductions/mask/x86/avx.rs
+++ b/src/codegen/reductions/mask/x86/avx.rs
@@ -10,12 +10,12 @@ macro_rules! x86_m8x32_avx_impl {
             #[target_feature(enable = "avx")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_testc_si256;
+                use crate::arch::x86::_mm256_testc_si256;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_testc_si256;
+                use crate::arch::x86_64::_mm256_testc_si256;
                 _mm256_testc_si256(
-                    ::mem::transmute(self),
-                    ::mem::transmute($id::splat(true)),
+                    crate::mem::transmute(self),
+                    crate::mem::transmute($id::splat(true)),
                 ) != 0
             }
         }
@@ -24,12 +24,12 @@ macro_rules! x86_m8x32_avx_impl {
             #[target_feature(enable = "avx")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_testz_si256;
+                use crate::arch::x86::_mm256_testz_si256;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_testz_si256;
+                use crate::arch::x86_64::_mm256_testz_si256;
                 _mm256_testz_si256(
-                    ::mem::transmute(self),
-                    ::mem::transmute(self),
+                    crate::mem::transmute(self),
+                    crate::mem::transmute(self),
                 ) == 0
             }
         }
@@ -44,13 +44,13 @@ macro_rules! x86_m32x8_avx_impl {
             #[target_feature(enable = "sse")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_ps;
+                use crate::arch::x86::_mm256_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_ps;
+                use crate::arch::x86_64::_mm256_movemask_ps;
                 // _mm256_movemask_ps(a) creates a 8bit mask containing the
                 // most significant bit of each lane of `a`. If all bits are
                 // set, then all 8 lanes of the mask are true.
-                _mm256_movemask_ps(::mem::transmute(self)) == 0b_1111_1111_i32
+                _mm256_movemask_ps(crate::mem::transmute(self)) == 0b_1111_1111_i32
             }
         }
         impl Any for $id {
@@ -58,11 +58,11 @@ macro_rules! x86_m32x8_avx_impl {
             #[target_feature(enable = "sse")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_ps;
+                use crate::arch::x86::_mm256_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_ps;
+                use crate::arch::x86_64::_mm256_movemask_ps;
 
-                _mm256_movemask_ps(::mem::transmute(self)) != 0
+                _mm256_movemask_ps(crate::mem::transmute(self)) != 0
             }
         }
     };
@@ -76,13 +76,13 @@ macro_rules! x86_m64x4_avx_impl {
             #[target_feature(enable = "sse")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_pd;
+                use crate::arch::x86::_mm256_movemask_pd;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_pd;
+                use crate::arch::x86_64::_mm256_movemask_pd;
                 // _mm256_movemask_pd(a) creates a 4bit mask containing the
                 // most significant bit of each lane of `a`. If all bits are
                 // set, then all 4 lanes of the mask are true.
-                _mm256_movemask_pd(::mem::transmute(self)) == 0b_1111_i32
+                _mm256_movemask_pd(crate::mem::transmute(self)) == 0b_1111_i32
             }
         }
         impl Any for $id {
@@ -90,13 +90,12 @@ macro_rules! x86_m64x4_avx_impl {
             #[target_feature(enable = "sse")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_pd;
+                use crate::arch::x86::_mm256_movemask_pd;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_pd;
+                use crate::arch::x86_64::_mm256_movemask_pd;
 
-                _mm256_movemask_pd(::mem::transmute(self)) != 0
+                _mm256_movemask_pd(crate::mem::transmute(self)) != 0
             }
         }
     };
 }
-

--- a/src/codegen/reductions/mask/x86/avx2.rs
+++ b/src/codegen/reductions/mask/x86/avx2.rs
@@ -9,14 +9,14 @@ macro_rules! x86_m8x32_avx2_impl {
             #[target_feature(enable = "sse2")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_epi8;
+                use crate::arch::x86::_mm256_movemask_epi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_epi8;
+                use crate::arch::x86_64::_mm256_movemask_epi8;
                 // _mm256_movemask_epi8(a) creates a 32bit mask containing the
                 // most significant bit of each byte of `a`. If all
                 // bits are set, then all 32 lanes of the mask are
                 // true.
-                _mm256_movemask_epi8(::mem::transmute(self)) == -1_i32
+                _mm256_movemask_epi8(crate::mem::transmute(self)) == -1_i32
             }
         }
         impl Any for $id {
@@ -24,11 +24,11 @@ macro_rules! x86_m8x32_avx2_impl {
             #[target_feature(enable = "sse2")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm256_movemask_epi8;
+                use crate::arch::x86::_mm256_movemask_epi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm256_movemask_epi8;
+                use crate::arch::x86_64::_mm256_movemask_epi8;
 
-                _mm256_movemask_epi8(::mem::transmute(self)) != 0
+                _mm256_movemask_epi8(crate::mem::transmute(self)) != 0
             }
         }
     };

--- a/src/codegen/reductions/mask/x86/mmx.rs
+++ b/src/codegen/reductions/mask/x86/mmx.rs
@@ -8,13 +8,13 @@ macro_rules! x86_m8x8_mmx_impl {
             #[target_feature(enable = "mmx")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_pi8;
+                use crate::arch::x86::_mm_movemask_pi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_pi8;
+                use crate::arch::x86_64::_mm_movemask_pi8;
                 // _mm_movemask_pi8(a) creates an 8bit mask containing the most
                 // significant bit of each byte of `a`. If all bits are set,
                 // then all 8 lanes of the mask are true.
-                _mm_movemask_pi8(::mem::transmute(self))
+                _mm_movemask_pi8(crate::mem::transmute(self))
                     == u8::max_value() as i32
             }
         }
@@ -23,11 +23,11 @@ macro_rules! x86_m8x8_mmx_impl {
             #[target_feature(enable = "mmx")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_pi8;
+                use crate::arch::x86::_mm_movemask_pi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_pi8;
+                use crate::arch::x86_64::_mm_movemask_pi8;
 
-                _mm_movemask_pi8(::mem::transmute(self)) != 0
+                _mm_movemask_pi8(crate::mem::transmute(self)) != 0
             }
         }
     };

--- a/src/codegen/reductions/mask/x86/sse.rs
+++ b/src/codegen/reductions/mask/x86/sse.rs
@@ -11,12 +11,12 @@ macro_rules! x86_m32x4_sse_impl {
                 #[cfg(target_arch = "x86")]
                 use ::arch::x86::_mm_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_ps;
+                use crate::arch::x86_64::_mm_movemask_ps;
                 // _mm_movemask_ps(a) creates a 4bit mask containing the
                 // most significant bit of each lane of `a`. If all
                 // bits are set, then all 4 lanes of the mask are
                 // true.
-                _mm_movemask_ps(::mem::transmute(self))
+                _mm_movemask_ps(crate::mem::transmute(self))
                     == 0b_1111_i32
             }
         }
@@ -27,9 +27,9 @@ macro_rules! x86_m32x4_sse_impl {
                 #[cfg(target_arch = "x86")]
                 use ::arch::x86::_mm_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_ps;
+                use crate::arch::x86_64::_mm_movemask_ps;
 
-                _mm_movemask_ps(::mem::transmute(self)) != 0
+                _mm_movemask_ps(crate::mem::transmute(self)) != 0
             }
         }
     };

--- a/src/codegen/reductions/mask/x86/sse.rs
+++ b/src/codegen/reductions/mask/x86/sse.rs
@@ -9,7 +9,7 @@ macro_rules! x86_m32x4_sse_impl {
             #[target_feature(enable = "sse")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_ps;
+                use crate::arch::x86::_mm_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
                 use crate::arch::x86_64::_mm_movemask_ps;
                 // _mm_movemask_ps(a) creates a 4bit mask containing the
@@ -25,7 +25,7 @@ macro_rules! x86_m32x4_sse_impl {
             #[target_feature(enable = "sse")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_ps;
+                use crate::arch::x86::_mm_movemask_ps;
                 #[cfg(target_arch = "x86_64")]
                 use crate::arch::x86_64::_mm_movemask_ps;
 

--- a/src/codegen/reductions/mask/x86/sse2.rs
+++ b/src/codegen/reductions/mask/x86/sse2.rs
@@ -9,14 +9,14 @@ macro_rules! x86_m64x2_sse2_impl {
             #[target_feature(enable = "sse")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_pd;
+                use crate::arch::x86::_mm_movemask_pd;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_pd;
+                use crate::arch::x86_64::_mm_movemask_pd;
                 // _mm_movemask_pd(a) creates a 2bit mask containing the
                 // most significant bit of each lane of `a`. If all
                 // bits are set, then all 2 lanes of the mask are
                 // true.
-                _mm_movemask_pd(::mem::transmute(self))
+                _mm_movemask_pd(crate::mem::transmute(self))
                     == 0b_11_i32
             }
         }
@@ -25,11 +25,11 @@ macro_rules! x86_m64x2_sse2_impl {
             #[target_feature(enable = "sse")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_pd;
+                use crate::arch::x86::_mm_movemask_pd;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_pd;
+                use crate::arch::x86_64::_mm_movemask_pd;
 
-                _mm_movemask_pd(::mem::transmute(self)) != 0
+                _mm_movemask_pd(crate::mem::transmute(self)) != 0
             }
         }
     };
@@ -43,14 +43,14 @@ macro_rules! x86_m8x16_sse2_impl {
             #[target_feature(enable = "sse2")]
             unsafe fn all(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_epi8;
+                use crate::arch::x86::_mm_movemask_epi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_epi8;
+                use crate::arch::x86_64::_mm_movemask_epi8;
                 // _mm_movemask_epi8(a) creates a 16bit mask containing the
                 // most significant bit of each byte of `a`. If all
                 // bits are set, then all 16 lanes of the mask are
                 // true.
-                _mm_movemask_epi8(::mem::transmute(self))
+                _mm_movemask_epi8(crate::mem::transmute(self))
                     == i32::from(u16::max_value())
             }
         }
@@ -59,11 +59,11 @@ macro_rules! x86_m8x16_sse2_impl {
             #[target_feature(enable = "sse2")]
             unsafe fn any(self) -> bool {
                 #[cfg(target_arch = "x86")]
-                use ::arch::x86::_mm_movemask_epi8;
+                use crate::arch::x86::_mm_movemask_epi8;
                 #[cfg(target_arch = "x86_64")]
-                use ::arch::x86_64::_mm_movemask_epi8;
+                use crate::arch::x86_64::_mm_movemask_epi8;
 
-                _mm_movemask_epi8(::mem::transmute(self)) != 0
+                _mm_movemask_epi8(crate::mem::transmute(self)) != 0
             }
         }
     };

--- a/src/codegen/shuffle.rs
+++ b/src/codegen/shuffle.rs
@@ -1,8 +1,8 @@
 //! Implementations of the `ShuffleResult` trait for the different numbers of
 //! lanes and vector element types.
 
-use masks::*;
-use sealed::Shuffle;
+use crate::masks::*;
+use crate::sealed::Shuffle;
 
 impl Shuffle<[u32; 2]> for i8 {
     type Output = crate::codegen::i8x2;

--- a/src/codegen/shuffle1_dyn.rs
+++ b/src/codegen/shuffle1_dyn.rs
@@ -1,10 +1,10 @@
 //! Shuffle vector lanes with run-time indices.
 
-use *;
+use crate::*;
 
 pub trait Shuffle1Dyn {
     type Indices;
-    fn shuffle1_dyn(self, Self::Indices) -> Self;
+    fn shuffle1_dyn(self, _: Self::Indices) -> Self;
 }
 
 // Fallback implementation
@@ -40,8 +40,8 @@ macro_rules! impl_shuffle1_dyn {
                         use arch::x86_64::_mm_shuffle_pi8;
 
                         unsafe {
-                            mem::transmute(_mm_shuffle_pi8(
-                                mem::transmute(self.0), mem::transmute(indices.0))
+                           crate::mem::transmute(_mm_shuffle_pi8(
+                               crate::mem::transmute(self.0),crate::mem::transmute(indices.0))
                             )
                         }
                     }
@@ -67,7 +67,7 @@ macro_rules! impl_shuffle1_dyn {
                         unsafe {
                             Simd(mem::transmute(
                                 vtbl1_u8(mem::transmute(self.0),
-                                         mem::transmute(indices.0))
+                                        crate::mem::transmute(indices.0))
                             ))
                         }
                     }
@@ -95,7 +95,7 @@ macro_rules! impl_shuffle1_dyn {
                         unsafe {
                             Simd(mem::transmute(
                                 _mm_shuffle_epi8(mem::transmute(self.0),
-                                                 mem::transmute(indices))
+                                                crate::mem::transmute(indices))
                             ))
                         }
                     }
@@ -114,7 +114,7 @@ macro_rules! impl_shuffle1_dyn {
                         unsafe {
                             Simd(mem::transmute(
                                 vqtbl1q_u8(mem::transmute(self.0),
-                                           mem::transmute(indices.0))
+                                          crate::mem::transmute(indices.0))
                             ))
                         }
                     }
@@ -138,8 +138,8 @@ macro_rules! impl_shuffle1_dyn {
 
                             let (i0, i1) = U { j: y }.s;
 
-                            let r0 = vtbl2_u8(mem::transmute(x), mem::transmute(i0));
-                            let r1 = vtbl2_u8(mem::transmute(x), mem::transmute(i1));
+                            let r0 = vtbl2_u8(mem::transmute(x),crate::mem::transmute(i0));
+                            let r1 = vtbl2_u8(mem::transmute(x),crate::mem::transmute(i1));
 
                             let r = U { s: (r0, r1) }.j;
 
@@ -163,8 +163,8 @@ macro_rules! impl_shuffle1_dyn {
                 let v = u8x16::new(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
                 let indices = indices + v;
                 unsafe {
-                    let s: u8x16 = mem::transmute(self);
-                    mem::transmute(s.shuffle1_dyn(indices))
+                    let s: u8x16 =crate::mem::transmute(self);
+                   crate::mem::transmute(s.shuffle1_dyn(indices))
                 }
             }
         }
@@ -183,8 +183,8 @@ macro_rules! impl_shuffle1_dyn {
                         use arch::x86_64::{_mm_permutevar_ps};
 
                         unsafe {
-                            mem::transmute(_mm_permutevar_ps(
-                                mem::transmute(self.0), mem::transmute(indices.0))
+                           crate::mem::transmute(_mm_permutevar_ps(
+                               crate::mem::transmute(self.0),crate::mem::transmute(indices.0))
                             )
                         }
                     }
@@ -200,8 +200,8 @@ macro_rules! impl_shuffle1_dyn {
                         let v = u8x16::new(0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3);
                         let indices = indices + v;
                         unsafe {
-                            let s: u8x16 = mem::transmute(self);
-                            mem::transmute(s.shuffle1_dyn(indices))
+                            let s: u8x16 =crate::mem::transmute(self);
+                           crate::mem::transmute(s.shuffle1_dyn(indices))
                         }
                     }
                 }
@@ -225,8 +225,8 @@ macro_rules! impl_shuffle1_dyn {
                         // 0b10 => 1:
                         let indices = indices << 1;
                         unsafe {
-                            mem::transmute(_mm_permutevar_pd(
-                                mem::transmute(self), mem::transmute(indices))
+                           crate::mem::transmute(_mm_permutevar_pd(
+                               crate::mem::transmute(self),crate::mem::transmute(indices))
                             )
                         }
                     }
@@ -242,8 +242,8 @@ macro_rules! impl_shuffle1_dyn {
                         let v = u8x16::new(0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
                         let indices = indices + v;
                         unsafe {
-                            let s: u8x16 = mem::transmute(self);
-                            mem::transmute(s.shuffle1_dyn(indices))
+                            let s: u8x16 =crate::mem::transmute(self);
+                           crate::mem::transmute(s.shuffle1_dyn(indices))
                         }
                     }
                 }
@@ -300,8 +300,8 @@ macro_rules! impl_shuffle1_dyn_non_u {
             #[inline]
             fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                 unsafe {
-                    let u: $uid = mem::transmute(self);
-                    mem::transmute(u.shuffle1_dyn(indices))
+                    let u: $uid = crate::mem::transmute(self);
+                    crate::mem::transmute(u.shuffle1_dyn(indices))
                 }
             }
         }
@@ -385,8 +385,8 @@ macro_rules! impl_shuffle1_dyn_ptr {
             #[inline]
             fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                 unsafe {
-                    let u: $uid = mem::transmute(self);
-                    mem::transmute(u.shuffle1_dyn(indices))
+                    let u: $uid = crate::mem::transmute(self);
+                    crate::mem::transmute(u.shuffle1_dyn(indices))
                 }
             }
         }

--- a/src/codegen/shuffle1_dyn.rs
+++ b/src/codegen/shuffle1_dyn.rs
@@ -35,9 +35,9 @@ macro_rules! impl_shuffle1_dyn {
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
-                        use arch::x86::_mm_shuffle_pi8;
+                        use crate::arch::x86::_mm_shuffle_pi8;
                         #[cfg(target_arch = "x86_64")]
-                        use arch::x86_64::_mm_shuffle_pi8;
+                        use crate::arch::x86_64::_mm_shuffle_pi8;
 
                         unsafe {
                            crate::mem::transmute(_mm_shuffle_pi8(
@@ -57,9 +57,9 @@ macro_rules! impl_shuffle1_dyn {
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(targt_arch = "aarch64")]
-                        use arch::aarch64::vtbl1_u8;
+                        use crate::arch::aarch64::vtbl1_u8;
                         #[cfg(targt_arch = "arm")]
-                        use arch::arm::vtbl1_u8;
+                        use crate::arch::arm::vtbl1_u8;
 
                         // This is safe because the binary is compiled with
                         // neon enabled at compile-time and can therefore only
@@ -86,9 +86,9 @@ macro_rules! impl_shuffle1_dyn {
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
-                        use arch::x86::_mm_shuffle_epi8;
+                        use crate::arch::x86::_mm_shuffle_epi8;
                         #[cfg(target_arch = "x86_64")]
-                        use arch::x86_64::_mm_shuffle_epi8;
+                        use crate::arch::x86_64::_mm_shuffle_epi8;
                         // This is safe because the binary is compiled with
                         // ssse3 enabled at compile-time and can therefore only
                         // run on CPUs that have it enabled.
@@ -106,7 +106,7 @@ macro_rules! impl_shuffle1_dyn {
                     type Indices = Self;
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
-                        use arch::aarch64::vqtbl1q_u8;
+                        use crate::arch::aarch64::vqtbl1q_u8;
 
                         // This is safe because the binary is compiled with
                         // neon enabled at compile-time and can therefore only
@@ -125,7 +125,7 @@ macro_rules! impl_shuffle1_dyn {
                     type Indices = Self;
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
-                        use arch::arm::vtbl2_u8;
+                        use crate::arch::arm::vtbl2_u8;
 
                         // This is safe because the binary is compiled with
                         // neon enabled at compile-time and can therefore only
@@ -178,9 +178,9 @@ macro_rules! impl_shuffle1_dyn {
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
-                        use arch::x86::{_mm_permutevar_ps};
+                        use crate::arch::x86::{_mm_permutevar_ps};
                         #[cfg(target_arch = "x86_64")]
-                        use arch::x86_64::{_mm_permutevar_ps};
+                        use crate::arch::x86_64::{_mm_permutevar_ps};
 
                         unsafe {
                            crate::mem::transmute(_mm_permutevar_ps(
@@ -217,9 +217,9 @@ macro_rules! impl_shuffle1_dyn {
                     #[inline]
                     fn shuffle1_dyn(self, indices: Self::Indices) -> Self {
                         #[cfg(target_arch = "x86")]
-                        use arch::x86::{_mm_permutevar_pd};
+                        use crate::arch::x86::{_mm_permutevar_pd};
                         #[cfg(target_arch = "x86_64")]
-                        use arch::x86_64::{_mm_permutevar_pd};
+                        use crate::arch::x86_64::{_mm_permutevar_pd};
                         // _mm_permutevar_pd uses the _second_ bit of each
                         // element to perform the selection, that is: 0b00 => 0,
                         // 0b10 => 1:

--- a/src/codegen/swap_bytes.rs
+++ b/src/codegen/swap_bytes.rs
@@ -27,9 +27,9 @@ macro_rules! impl_swap_bytes {
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_transmute))]
                 fn swap_bytes(self) -> Self {
                     unsafe {
-                        let bytes: u8x4 = ::mem::transmute(self);
+                        let bytes: u8x4 = crate::mem::transmute(self);
                         let result: u8x4 = shuffle!(bytes, [3, 2, 1, 0]);
-                        ::mem::transmute(result)
+                        crate::mem::transmute(result)
                     }
                 }
             }
@@ -42,9 +42,9 @@ macro_rules! impl_swap_bytes {
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_transmute))]
                 fn swap_bytes(self) -> Self {
                     unsafe {
-                        let bytes: u8x8 = ::mem::transmute(self);
+                        let bytes: u8x8 = crate::mem::transmute(self);
                         let result: u8x8 = shuffle!(bytes, [7, 6, 5, 4, 3, 2, 1, 0]);
-                        ::mem::transmute(result)
+                        crate::mem::transmute(result)
                     }
                 }
             }
@@ -57,11 +57,11 @@ macro_rules! impl_swap_bytes {
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_transmute))]
                 fn swap_bytes(self) -> Self {
                     unsafe {
-                        let bytes: u8x16 = ::mem::transmute(self);
+                        let bytes: u8x16 = crate::mem::transmute(self);
                         let result: u8x16 = shuffle!(bytes, [
                             15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
                         ]);
-                        ::mem::transmute(result)
+                        crate::mem::transmute(result)
                     }
                 }
             }
@@ -74,12 +74,12 @@ macro_rules! impl_swap_bytes {
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_transmute))]
                 fn swap_bytes(self) -> Self {
                     unsafe {
-                        let bytes: u8x32 = ::mem::transmute(self);
+                        let bytes: u8x32 = crate::mem::transmute(self);
                         let result: u8x32 = shuffle!(bytes, [
                             31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                             15, 14, 13, 12, 11, 10, 9,  8,  7,  6,  5,  4,  3,  2,  1,  0
                         ]);
-                        ::mem::transmute(result)
+                        crate::mem::transmute(result)
                     }
                 }
             }
@@ -92,14 +92,14 @@ macro_rules! impl_swap_bytes {
                 #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_transmute))]
                 fn swap_bytes(self) -> Self {
                     unsafe {
-                        let bytes: u8x64 = ::mem::transmute(self);
+                        let bytes: u8x64 = crate::mem::transmute(self);
                         let result: u8x64 = shuffle!(bytes, [
                             63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48,
                             47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32,
                             31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                             15, 14, 13, 12, 11, 10, 9,  8,  7,  6,  5,  4,  3,  2,  1,  0
                         ]);
-                        ::mem::transmute(result)
+                        crate::mem::transmute(result)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,11 +165,11 @@
 //!   patterns of the target type and are also implemented for the
 //!   architecture-specific vector types of `std::arch`. For example, `let x:
 //!   u8x8 = m8x8::splat(true).into_bits();` is provided because all `m8x8` bit
-//!   patterns are valid `u8x8` bit patterns. However, the opposite is not
-//! true,   not all `u8x8` bit patterns are valid `m8x8` bit-patterns, so this
+//!   patterns are valid `u8x8` bit patterns. However, the opposite is not true,
+//!   not all `u8x8` bit patterns are valid `m8x8` bit-patterns, so this
 //!   operation cannot be peformed safely using `x.into_bits()`; one needs to
-//!   use `unsafe { mem::transmute(x) }` for that, making sure that the value
-//! in   the `u8x8` is a valid bit-pattern of `m8x8`.
+//!   use `unsafe { crate::mem::transmute(x) }` for that, making sure that the
+//!   value in the `u8x8` is a valid bit-pattern of `m8x8`.
 //!
 //! * **numeric casts** (`as`): are peformed using [`FromCast`]/[`Cast`]
 //! (`x.cast()`), just like `as`:
@@ -199,7 +199,6 @@
 //!   preserving, etc.
 
 #![feature(
-    rust_2018_preview,
     repr_simd,
     const_fn,
     platform_intrinsics,
@@ -230,16 +229,14 @@
 #![cfg_attr(
     feature = "cargo-clippy", deny(clippy::missing_inline_in_public_items)
 )]
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![no_std]
 
-#[macro_use]
-extern crate cfg_if;
+use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(all(target_arch = "arm", target_feature = "v7", target_feature = "neon",
                  feature = "coresimd"))] {
-        extern crate coresimd;
         #[allow(unused_imports)]
         use coresimd::arch;
     } else {
@@ -247,12 +244,6 @@ cfg_if! {
         use core::arch;
     }
 }
-
-#[cfg(test)]
-extern crate arrayvec;
-
-#[cfg(all(target_arch = "wasm32", test))]
-extern crate wasm_bindgen_test;
 
 #[cfg(all(target_arch = "wasm32", test))]
 use wasm_bindgen_test::*;
@@ -262,9 +253,6 @@ use core::{
     /* arch (handled above), */ cmp, default, f32, f64, fmt, hash, hint,
     intrinsics, iter, marker, mem, ops, ptr, slice,
 };
-
-#[cfg(all(target_arch = "x86_64", feature = "sleef-sys"))]
-extern crate sleef_sys;
 
 #[macro_use]
 mod testing;
@@ -343,5 +331,5 @@ pub use self::codegen::llvm::{
 };
 
 crate mod llvm {
-    crate use codegen::llvm::*;
+    crate use crate::codegen::llvm::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,8 @@
 //!   patterns of the target type and are also implemented for the
 //!   architecture-specific vector types of `std::arch`. For example, `let x:
 //!   u8x8 = m8x8::splat(true).into_bits();` is provided because all `m8x8` bit
-//!   patterns are valid `u8x8` bit patterns. However, the opposite is not true,
-//!   not all `u8x8` bit patterns are valid `m8x8` bit-patterns, so this
+//!   patterns are valid `u8x8` bit patterns. However, the opposite is not
+//! true,   not all `u8x8` bit patterns are valid `m8x8` bit-patterns, so this
 //!   operation cannot be peformed safely using `x.into_bits()`; one needs to
 //!   use `unsafe { crate::mem::transmute(x) }` for that, making sure that the
 //!   value in the `u8x8` is a valid bit-pattern of `m8x8`.
@@ -250,8 +250,9 @@ use wasm_bindgen_test::*;
 
 #[allow(unused_imports)]
 use core::{
-    /* arch (handled above), */ cmp, default, f32, f64, fmt, hash, hint,
-    intrinsics, iter, marker, mem, ops, ptr, slice,
+    /* arch (handled above), */ cmp, f32, f64, fmt, hash, hint, i128,
+    i16, i32, i64, i8, intrinsics, isize, iter, marker, mem, ops, ptr, slice,
+    u128, u16, u32, u64, u8, usize,
 };
 
 #[macro_use]

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -107,7 +107,7 @@ macro_rules! impl_mask_ty {
             #[inline]
             #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
             fn fmt(
-                &self, fmtter: &mut crate::fmt::Formatter,
+                &self, fmtter: &mut crate::fmt::Formatter<'_>,
             ) -> Result<(), crate::fmt::Error> {
                 write!(fmtter, "{}({})", stringify!($id), self.0 != 0)
             }

--- a/src/testing/utils.rs
+++ b/src/testing/utils.rs
@@ -55,7 +55,7 @@ pub fn test_le<T>(
 /// Test PartialOrd::partial_cmp for `a` and `b` returning `Ordering`
 pub fn test_cmp<T>(
     a: LexicographicallyOrdered<T>, b: LexicographicallyOrdered<T>,
-    o: Option<::cmp::Ordering>,
+    o: Option<crate::cmp::Ordering>,
 ) where
     LexicographicallyOrdered<T>: PartialOrd + Debug,
     T: Debug + crate::sealed::Simd + Copy + Clone,
@@ -66,13 +66,13 @@ pub fn test_cmp<T>(
     let mut arr_b: [T::Element; 64] = [Default::default(); 64];
 
     unsafe {
-        cratecrate::ptr::write_unaligned(
+        crate::ptr::write_unaligned(
             arr_a.as_mut_ptr() as *mut LexicographicallyOrdered<T>,
             a,
         )
     }
     unsafe {
-        cratecrate::ptr::write_unaligned(
+        crate::ptr::write_unaligned(
             arr_b.as_mut_ptr() as *mut LexicographicallyOrdered<T>,
             b,
         )
@@ -82,15 +82,15 @@ pub fn test_cmp<T>(
     assert_eq!(expected, result, "{:?}, {:?}", a, b);
     assert_eq!(o, result, "{:?}, {:?}", a, b);
     match o {
-        Some(::cmp::Ordering::Less) => {
+        Some(crate::cmp::Ordering::Less) => {
             test_lt(a, b);
             test_le(a, b);
         }
-        Some(::cmp::Ordering::Greater) => {
+        Some(crate::cmp::Ordering::Greater) => {
             test_lt(b, a);
             test_le(b, a);
         }
-        Some(::cmp::Ordering::Equal) => {
+        Some(crate::cmp::Ordering::Equal) => {
             assert!(a == b, "{:?}, {:?}", a, b);
             assert!(!(a != b), "{:?}, {:?}", a, b);
             assert!(!(a < b), "{:?}, {:?}", a, b);

--- a/src/testing/utils.rs
+++ b/src/testing/utils.rs
@@ -66,13 +66,13 @@ pub fn test_cmp<T>(
     let mut arr_b: [T::Element; 64] = [Default::default(); 64];
 
     unsafe {
-        crate::ptr::write_unaligned(
+        cratecrate::ptr::write_unaligned(
             arr_a.as_mut_ptr() as *mut LexicographicallyOrdered<T>,
             a,
         )
     }
     unsafe {
-        crate::ptr::write_unaligned(
+        cratecrate::ptr::write_unaligned(
             arr_b.as_mut_ptr() as *mut LexicographicallyOrdered<T>,
             b,
         )
@@ -125,10 +125,11 @@ macro_rules! ptr_vals {
         #[allow(unused_unsafe)]
         unsafe {
             // all bits cleared
-            let mut clear: <$id as sealed::Simd>::Element = mem::zeroed();
+            let mut clear: <$id as sealed::Simd>::Element =
+                crate::mem::zeroed();
             // all bits set
             let mut set: <$id as sealed::Simd>::Element =
-                mem::transmute(-1_isize);
+                crate::mem::transmute(-1_isize);
             (clear, set)
         }
     };

--- a/src/v64.rs
+++ b/src/v64.rs
@@ -1,6 +1,6 @@
 //! 64-bit wide vector types
 
-use crate::*;
+use super::*;
 
 impl_i!([i8; 8]: i8x8, m8x8 | i8 | test_v64 | x0, x1, x2, x3, x4, x5, x6, x7 |
         From: |

--- a/tests/endianness.rs
+++ b/tests/endianness.rs
@@ -22,7 +22,7 @@ fn endian_bitcasts() {
         0, 1, 2, 3, 4, 5, 6, 7,
         8, 9, 10, 11, 12, 13, 14, 15,
     );
-    let t: i16x8 = unsafe { core::mem::transmute(x) };
+    let t: i16x8 = unsafe { mem::transmute(x) };
     let e: i16x8 = if cfg!(target_endian = "little") {
         i16x8::new(256, 770, 1284, 1798, 2312, 2826, 3340, 3854)
     } else {

--- a/tests/endianness.rs
+++ b/tests/endianness.rs
@@ -1,8 +1,3 @@
-extern crate packed_simd;
-
-#[cfg(target_arch = "wasm32")]
-extern crate wasm_bindgen_test;
-
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -27,7 +22,7 @@ fn endian_bitcasts() {
         0, 1, 2, 3, 4, 5, 6, 7,
         8, 9, 10, 11, 12, 13, 14, 15,
     );
-    let t: i16x8 = unsafe { mem::transmute(x) };
+    let t: i16x8 = unsafe { core::mem::transmute(x) };
     let e: i16x8 = if cfg!(target_endian = "little") {
         i16x8::new(256, 770, 1284, 1798, 2312, 2826, 3340, 3854)
     } else {

--- a/verify/verify/Cargo.toml
+++ b/verify/verify/Cargo.toml
@@ -2,6 +2,7 @@
 name = "verify"
 version = "0.1.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
+edition = "2018"
 
 [dev-dependencies]
 stdsimd-test = { git = "https://github.com/rust-lang-nursery/stdsimd.git"  }

--- a/verify/verify/src/api.rs
+++ b/verify/verify/src/api.rs
@@ -1,3 +1,11 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(debug_assertions)] {
+        compile_error!("the verify tests only run in --release mode");
+    }
+}
+
 mod math;
 mod ops;
 mod reductions;

--- a/verify/verify/src/api/ops/vector_rotates.rs
+++ b/verify/verify/src/api/ops/vector_rotates.rs
@@ -1,3 +1,5 @@
+use cfg_if::cfg_if;
+
 cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
         mod x86;

--- a/verify/verify/src/api/reductions/mask.rs
+++ b/verify/verify/src/api/reductions/mask.rs
@@ -1,5 +1,7 @@
 //! Verify the mask reduction API.
 
+use cfg_if::cfg_if;
+
 #[allow(unused)]
 macro_rules! verify_mask {
     ($mask_id:ident[$target_feature:tt] => $all_instr:tt, $any_instr:tt, $none_instr:tt) => {

--- a/verify/verify/src/lib.rs
+++ b/verify/verify/src/lib.rs
@@ -1,14 +1,6 @@
-#![cfg(test)]
 #![deny(warnings, rust_2018_idioms)]
-#![feature(plugin, avx512_target_feature, abi_vectorcall)]
-#![plugin(interpolate_idents)]
+#![cfg_attr(test, feature(plugin, avx512_target_feature, abi_vectorcall))]
+#![cfg_attr(test, plugin(interpolate_idents))]
 
-use cfg_if::cfg_if;
-
+#[cfg(test)]
 mod api;
-
-cfg_if! {
-    if #[cfg(debug_assertions)] {
-        compile_error!("the verify tests only run in --release mode");
-    }
-}

--- a/verify/verify/src/lib.rs
+++ b/verify/verify/src/lib.rs
@@ -1,24 +1,12 @@
-#![deny(warnings)]
-#![cfg_attr(
-    test,
-    feature(plugin, rust_2018_preview, avx512_target_feature, abi_vectorcall)
-)]
-#![cfg_attr(test, plugin(interpolate_idents))]
+#![cfg(test)]
+#![deny(warnings, rust_2018_idioms)]
+#![feature(plugin, avx512_target_feature, abi_vectorcall)]
+#![plugin(interpolate_idents)]
 
-#[cfg(test)]
-extern crate packed_simd;
+use cfg_if::cfg_if;
 
-#[cfg(test)]
-extern crate stdsimd_test;
-
-#[cfg(test)]
-#[macro_use]
-extern crate cfg_if;
-
-#[cfg(test)]
 mod api;
 
-#[cfg(test)]
 cfg_if! {
     if #[cfg(debug_assertions)] {
         compile_error!("the verify tests only run in --release mode");


### PR DESCRIPTION
The main crate and the examples have been updated to Rust 2018, as well as the `verify` and `micro_benchmarks` crates. Also fixes #167.