### PR TITLE
Remove unnecessary Clippy lint and re-run fmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,4 +3,4 @@ use_small_heuristics = "Max"
 wrap_comments = true
 comment_width = 79
 fn_args_density = "Compressed"
-edition = "Edition2018"
+edition = "2018"

--- a/src/api/fmt/binary.rs
+++ b/src/api/fmt/binary.rs
@@ -7,8 +7,6 @@ macro_rules! impl_fmt_binary {
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
             fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/api/fmt/debug.rs
+++ b/src/api/fmt/debug.rs
@@ -49,10 +49,6 @@ macro_rules! impl_fmt_debug {
             fn fmt(
                 &self, f: &mut crate::fmt::Formatter<'_>,
             ) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(
-                    feature = "cargo-clippy", allow(clippy::write_literal)
-                )]
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/api/fmt/lower_hex.rs
+++ b/src/api/fmt/lower_hex.rs
@@ -7,8 +7,6 @@ macro_rules! impl_fmt_lower_hex {
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
             fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/api/fmt/octal.rs
+++ b/src/api/fmt/octal.rs
@@ -7,8 +7,6 @@ macro_rules! impl_fmt_octal {
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
             fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/api/fmt/upper_hex.rs
+++ b/src/api/fmt/upper_hex.rs
@@ -7,8 +7,6 @@ macro_rules! impl_fmt_upper_hex {
                 feature = "cargo-clippy", allow(clippy::missing_inline_in_public_items)
             )]
             fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}(", stringify!($id))?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/api/into_bits.rs
+++ b/src/api/into_bits.rs
@@ -19,7 +19,9 @@ where
 {
     #[inline]
     fn into_bits(self) -> U {
-        debug_assert!(crate::mem::size_of::<Self>() == crate::mem::size_of::<U>());
+        debug_assert!(
+            crate::mem::size_of::<Self>() == crate::mem::size_of::<U>()
+        );
         U::from_bits(self)
     }
 }

--- a/src/api/minimal/ptr.rs
+++ b/src/api/minimal/ptr.rs
@@ -186,8 +186,6 @@ macro_rules! impl_minimal_p {
             #[cfg_attr(feature = "cargo-clippy",
                        allow(clippy::missing_inline_in_public_items))]
             fn fmt(&self, f: &mut crate::fmt::Formatter<'_>) -> crate::fmt::Result {
-                // FIXME: https://github.com/rust-lang-nursery/rust-clippy/issues/2891
-                #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
                 write!(f, "{}<{}>(", stringify!($id), unsafe { crate::intrinsics::type_name::<T>() })?;
                 for i in 0..$elem_count {
                     if i > 0 {

--- a/src/codegen/math/float/sin_cos_pi.rs
+++ b/src/codegen/math/float/sin_cos_pi.rs
@@ -132,7 +132,8 @@ macro_rules! impl_unary_t {
                             [res_0.0, res_1.0, res_2.0, res_3.0],
                             [res_0.1, res_1.1, res_2.1, res_3.1],
                         ),
-                    }.result
+                    }
+                    .result
                 }
             }
         }

--- a/src/codegen/math/float/sqrte.rs
+++ b/src/codegen/math/float/sqrte.rs
@@ -3,8 +3,8 @@
 
 // FIXME 64-bit 1 elem vectors sqrte
 
-use crate::*;
 use crate::llvm::simd_fsqrt;
+use crate::*;
 
 crate trait Sqrte {
     fn sqrte(self) -> Self;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@
     align_offset,
     mmx_target_feature,
     crate_visibility_modifier,
-    custom_inner_attributes,
+    custom_inner_attributes
 )]
 #![allow(non_camel_case_types, non_snake_case)]
 #![cfg_attr(test, feature(plugin, hashmap_internals))]

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -105,7 +105,6 @@ macro_rules! impl_mask_ty {
 
         impl crate::fmt::Debug for $id {
             #[inline]
-            #[cfg_attr(feature = "cargo-clippy", allow(clippy::write_literal))]
             fn fmt(
                 &self, fmtter: &mut crate::fmt::Formatter<'_>,
             ) -> Result<(), crate::fmt::Error> {


### PR DESCRIPTION
Fixes #179.

Also updates `rustfmt.toml` to make formatting work again.