### PR TITLE
Fix Clippy lints

### DIFF
--- a/examples/aobench/src/random.rs
+++ b/examples/aobench/src/random.rs
@@ -25,7 +25,7 @@ pub mod scalar {
                 | ((x & 0xff00_u32) << 8)
                 | ((x & 0x00ff_0000_u32) >> 8)
                 | (x & 0xff00_0000_u32) >> 24;
-            RngT(z0, z1, z2, z3)
+            Self(z0, z1, z2, z3)
         }
 
         pub fn gen_u32(&mut self) -> u32 {
@@ -88,7 +88,7 @@ pub mod vector {
                 | ((x & u32xN::splat(0xff00)) << 8)
                 | ((x & u32xN::splat(0x00ff_0000)) >> 8)
                 | (x & u32xN::splat(0xff00_0000)) >> 24;
-            RngT(z0, z1, z2, z3)
+            Self(z0, z1, z2, z3)
         }
 
         #[inline(always)]

--- a/examples/spectral_norm/src/scalar.rs
+++ b/examples/spectral_norm/src/scalar.rs
@@ -10,13 +10,13 @@ struct f64x2(f64, f64);
 impl Add for f64x2 {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        f64x2(self.0 + rhs.0, self.1 + rhs.1)
+        Self(self.0 + rhs.0, self.1 + rhs.1)
     }
 }
 impl Div for f64x2 {
     type Output = Self;
     fn div(self, rhs: Self) -> Self {
-        f64x2(self.0 / rhs.0, self.1 / rhs.1)
+        Self(self.0 / rhs.0, self.1 / rhs.1)
     }
 }
 

--- a/examples/triangle_xform/src/scalar.rs
+++ b/examples/triangle_xform/src/scalar.rs
@@ -33,7 +33,7 @@ impl Triangle {
             xformed[k] = [x, y, z];
         }
 
-        Triangle(xformed)
+        Self(xformed)
     }
 }
 

--- a/src/api/cast.rs
+++ b/src/api/cast.rs
@@ -1,5 +1,11 @@
 //! Implementation of `FromCast` and `IntoCast`.
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::stutter))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        clippy::module_name_repetitions,
+        clippy::stutter
+    )
+)]
 
 /// Numeric cast from `T` to `Self`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,10 @@
         clippy::cast_possible_truncation,
         clippy::cast_lossless,
         clippy::cast_possible_wrap,
-        clippy::cast_precision_loss
+        clippy::cast_precision_loss,
+        // This lint is currently broken for generic code
+        // See https://github.com/rust-lang/rust-clippy/issues/3410
+        clippy::use_self
     )
 )]
 #![cfg_attr(


### PR DESCRIPTION
This PR attempts to get CI working again by fixing some of the reported Clippy lints.

The biggest issue has been caused by the `use_self` lint, which recommends using the `Self` type where possible. However, it has a [known limitation](https://github.com/rust-lang/rust-clippy/issues/3410) when used with generic code and / or associated types. So for now, it is disabled on the whole `packed_simd` crate.