### PR TITLE
Enable building with non-nightly complier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["simd", "vector", "portability"]
 categories = ["hardware-support", "concurrency", "no-std", "data-structures"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+build = "build.rs"
 
 [badges]
 appveyor = { repository = "rust-lang-nursery/packed_simd" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+}


### PR DESCRIPTION
A recent [compiler change](https://github.com/rust-lang/rust/pull/57416) removed support for compiling the `simd` crate. As a result, it [seems](https://bugzilla.mozilla.org/show_bug.cgi?id=1521249) that Firefox needs to migrate to `packed_simd` before `packed_simd` becomes `core::simd`.

The Firefox build system previously had problems with setting `RUSTC_BOOTSTRAP=1` on the build system level and, as a result, migrated to relying on individual crates setting `RUSTC_BOOTSTRAP=1` in their `build.rs` (first in order to use a custom allocator, but at present the only use case is the `simd` crate).

I believe this PR makes `packed_simd` compatible with the Firefox build system.