### PR TITLE
Update the cfg_if version requirement to 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ is-it-maintained-open-issues = { repository = "rust-lang-nursery/packed_simd" }
 maintenance = { status = "experimental" }
 
 [dependencies]
-cfg-if = "^0.1"
+cfg-if = "^0.1.6"
 core_arch = { version = "^0.1.3", optional = true }
 
 [features]


### PR DESCRIPTION
Old versions of cfg_if are edition 2018-incompatible. According to
https://bugzilla.mozilla.org/show_bug.cgi?id=1526924#c13 , 0.1.5
is required. The commit history of cfg_if suggests that 0.1.6 contains
another edition 2018 compatibility change, so updating to 0.1.6.