### PR TITLE
Remove align_offset feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,6 @@
     link_llvm_intrinsics,
     core_intrinsics,
     stmt_expr_attributes,
-    align_offset,
     mmx_target_feature,
     crate_visibility_modifier,
     custom_inner_attributes


### PR DESCRIPTION
This unstable feature has been stabilized in the latest nightlies. Fixes #246.