### PR TITLE
Implement the sealed trait pattern

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -16,6 +16,8 @@ macro_rules! impl_simd_array {
         pub struct $tuple_id($(crate $elem_tys),*);
         //^^^^^^^ leaked through SimdArray
 
+        impl crate::sealed::Seal for [$elem_ty; $elem_count] {}
+
         impl crate::sealed::SimdArray for [$elem_ty; $elem_count] {
             type Tuple = $tuple_id;
             type T = $elem_ty;
@@ -23,6 +25,7 @@ macro_rules! impl_simd_array {
             type NT = [u32; $elem_count];
         }
 
+        impl crate::sealed::Seal for $tuple_id {}
         impl crate::sealed::Simd for $tuple_id {
             type Element = $elem_ty;
             const LANES: usize = $elem_count;

--- a/src/codegen/shuffle.rs
+++ b/src/codegen/shuffle.rs
@@ -2,301 +2,149 @@
 //! lanes and vector element types.
 
 use crate::masks::*;
-use crate::sealed::Shuffle;
+use crate::sealed::{Shuffle, Seal};
 
-impl Shuffle<[u32; 2]> for i8 {
-    type Output = crate::codegen::i8x2;
-}
-impl Shuffle<[u32; 4]> for i8 {
-    type Output = crate::codegen::i8x4;
-}
-impl Shuffle<[u32; 8]> for i8 {
-    type Output = crate::codegen::i8x8;
-}
-impl Shuffle<[u32; 16]> for i8 {
-    type Output = crate::codegen::i8x16;
-}
-impl Shuffle<[u32; 32]> for i8 {
-    type Output = crate::codegen::i8x32;
-}
-impl Shuffle<[u32; 64]> for i8 {
-    type Output = crate::codegen::i8x64;
+macro_rules! impl_shuffle {
+    ($array:ty, $base:ty, $out:ty) => {
+        impl Seal<$array> for $base {}
+        impl Shuffle<$array> for $base {
+            type Output = $out;
+        }
+    }
 }
 
-impl Shuffle<[u32; 2]> for u8 {
-    type Output = crate::codegen::u8x2;
-}
-impl Shuffle<[u32; 4]> for u8 {
-    type Output = crate::codegen::u8x4;
-}
-impl Shuffle<[u32; 8]> for u8 {
-    type Output = crate::codegen::u8x8;
-}
-impl Shuffle<[u32; 16]> for u8 {
-    type Output = crate::codegen::u8x16;
-}
-impl Shuffle<[u32; 32]> for u8 {
-    type Output = crate::codegen::u8x32;
-}
-impl Shuffle<[u32; 64]> for u8 {
-    type Output = crate::codegen::u8x64;
-}
+impl_shuffle! { [u32; 2], i8, crate::codegen::i8x2 }
+impl_shuffle! { [u32; 4], i8, crate::codegen::i8x4 }
+impl_shuffle! { [u32; 8], i8, crate::codegen::i8x8 }
+impl_shuffle! { [u32; 16], i8, crate::codegen::i8x16 }
+impl_shuffle! { [u32; 32], i8, crate::codegen::i8x32 }
+impl_shuffle! { [u32; 64], i8, crate::codegen::i8x64 }
 
-impl Shuffle<[u32; 2]> for m8 {
-    type Output = crate::codegen::m8x2;
-}
-impl Shuffle<[u32; 4]> for m8 {
-    type Output = crate::codegen::m8x4;
-}
-impl Shuffle<[u32; 8]> for m8 {
-    type Output = crate::codegen::m8x8;
-}
-impl Shuffle<[u32; 16]> for m8 {
-    type Output = crate::codegen::m8x16;
-}
-impl Shuffle<[u32; 32]> for m8 {
-    type Output = crate::codegen::m8x32;
-}
-impl Shuffle<[u32; 64]> for m8 {
-    type Output = crate::codegen::m8x64;
-}
+impl_shuffle! { [u32; 2], u8, crate::codegen::u8x2 }
+impl_shuffle! { [u32; 4], u8, crate::codegen::u8x4 }
+impl_shuffle! { [u32; 8], u8, crate::codegen::u8x8 }
+impl_shuffle! { [u32; 16], u8, crate::codegen::u8x16 }
+impl_shuffle! { [u32; 32], u8, crate::codegen::u8x32 }
+impl_shuffle! { [u32; 64], u8, crate::codegen::u8x64 }
 
-impl Shuffle<[u32; 2]> for i16 {
-    type Output = crate::codegen::i16x2;
-}
-impl Shuffle<[u32; 4]> for i16 {
-    type Output = crate::codegen::i16x4;
-}
-impl Shuffle<[u32; 8]> for i16 {
-    type Output = crate::codegen::i16x8;
-}
-impl Shuffle<[u32; 16]> for i16 {
-    type Output = crate::codegen::i16x16;
-}
-impl Shuffle<[u32; 32]> for i16 {
-    type Output = crate::codegen::i16x32;
-}
+impl_shuffle! { [u32; 2], m8, crate::codegen::m8x2 }
+impl_shuffle! { [u32; 4], m8, crate::codegen::m8x4 }
+impl_shuffle! { [u32; 8], m8, crate::codegen::m8x8 }
+impl_shuffle! { [u32; 16], m8, crate::codegen::m8x16 }
+impl_shuffle! { [u32; 32], m8, crate::codegen::m8x32 }
+impl_shuffle! { [u32; 64], m8, crate::codegen::m8x64 }
 
-impl Shuffle<[u32; 2]> for u16 {
-    type Output = crate::codegen::u16x2;
-}
-impl Shuffle<[u32; 4]> for u16 {
-    type Output = crate::codegen::u16x4;
-}
-impl Shuffle<[u32; 8]> for u16 {
-    type Output = crate::codegen::u16x8;
-}
-impl Shuffle<[u32; 16]> for u16 {
-    type Output = crate::codegen::u16x16;
-}
-impl Shuffle<[u32; 32]> for u16 {
-    type Output = crate::codegen::u16x32;
-}
+impl_shuffle! { [u32; 2], i16, crate::codegen::i16x2 }
+impl_shuffle! { [u32; 4], i16, crate::codegen::i16x4 }
+impl_shuffle! { [u32; 8], i16, crate::codegen::i16x8 }
+impl_shuffle! { [u32; 16], i16, crate::codegen::i16x16 }
+impl_shuffle! { [u32; 32], i16, crate::codegen::i16x32 }
 
-impl Shuffle<[u32; 2]> for m16 {
-    type Output = crate::codegen::m16x2;
-}
-impl Shuffle<[u32; 4]> for m16 {
-    type Output = crate::codegen::m16x4;
-}
-impl Shuffle<[u32; 8]> for m16 {
-    type Output = crate::codegen::m16x8;
-}
-impl Shuffle<[u32; 16]> for m16 {
-    type Output = crate::codegen::m16x16;
-}
-impl Shuffle<[u32; 32]> for m16 {
-    type Output = crate::codegen::m16x32;
-}
+impl_shuffle! { [u32; 2], u16, crate::codegen::u16x2 }
+impl_shuffle! { [u32; 4], u16, crate::codegen::u16x4 }
+impl_shuffle! { [u32; 8], u16, crate::codegen::u16x8 }
+impl_shuffle! { [u32; 16], u16, crate::codegen::u16x16 }
+impl_shuffle! { [u32; 32], u16, crate::codegen::u16x32 }
 
-impl Shuffle<[u32; 2]> for i32 {
-    type Output = crate::codegen::i32x2;
-}
-impl Shuffle<[u32; 4]> for i32 {
-    type Output = crate::codegen::i32x4;
-}
-impl Shuffle<[u32; 8]> for i32 {
-    type Output = crate::codegen::i32x8;
-}
-impl Shuffle<[u32; 16]> for i32 {
-    type Output = crate::codegen::i32x16;
-}
+impl_shuffle! { [u32; 2], m16, crate::codegen::m16x2 }
+impl_shuffle! { [u32; 4], m16, crate::codegen::m16x4 }
+impl_shuffle! { [u32; 8], m16, crate::codegen::m16x8 }
+impl_shuffle! { [u32; 16], m16, crate::codegen::m16x16 }
 
-impl Shuffle<[u32; 2]> for u32 {
-    type Output = crate::codegen::u32x2;
-}
-impl Shuffle<[u32; 4]> for u32 {
-    type Output = crate::codegen::u32x4;
-}
-impl Shuffle<[u32; 8]> for u32 {
-    type Output = crate::codegen::u32x8;
-}
-impl Shuffle<[u32; 16]> for u32 {
-    type Output = crate::codegen::u32x16;
-}
+impl_shuffle! { [u32; 2], i32, crate::codegen::i32x2 }
+impl_shuffle! { [u32; 4], i32, crate::codegen::i32x4 }
+impl_shuffle! { [u32; 8], i32, crate::codegen::i32x8 }
+impl_shuffle! { [u32; 16], i32, crate::codegen::i32x16 }
 
-impl Shuffle<[u32; 2]> for f32 {
-    type Output = crate::codegen::f32x2;
-}
-impl Shuffle<[u32; 4]> for f32 {
-    type Output = crate::codegen::f32x4;
-}
-impl Shuffle<[u32; 8]> for f32 {
-    type Output = crate::codegen::f32x8;
-}
-impl Shuffle<[u32; 16]> for f32 {
-    type Output = crate::codegen::f32x16;
-}
+impl_shuffle! { [u32; 2], u32, crate::codegen::u32x2 }
+impl_shuffle! { [u32; 4], u32, crate::codegen::u32x4 }
+impl_shuffle! { [u32; 8], u32, crate::codegen::u32x8 }
+impl_shuffle! { [u32; 16], u32, crate::codegen::u32x16 }
 
-impl Shuffle<[u32; 2]> for m32 {
-    type Output = crate::codegen::m32x2;
-}
-impl Shuffle<[u32; 4]> for m32 {
-    type Output = crate::codegen::m32x4;
-}
-impl Shuffle<[u32; 8]> for m32 {
-    type Output = crate::codegen::m32x8;
-}
-impl Shuffle<[u32; 16]> for m32 {
-    type Output = crate::codegen::m32x16;
-}
+impl_shuffle! { [u32; 2], f32, crate::codegen::f32x2 }
+impl_shuffle! { [u32; 4], f32, crate::codegen::f32x4 }
+impl_shuffle! { [u32; 8], f32, crate::codegen::f32x8 }
+impl_shuffle! { [u32; 16], f32, crate::codegen::f32x16 }
+
+impl_shuffle! { [u32; 2], m32, crate::codegen::m32x2 }
+impl_shuffle! { [u32; 4], m32, crate::codegen::m32x4 }
+impl_shuffle! { [u32; 8], m32, crate::codegen::m32x8 }
+impl_shuffle! { [u32; 16], m32, crate::codegen::m32x16 }
 
 /* FIXME: 64-bit single element vector
-impl Shuffle<[u32; 1]> for i64 {
-    type Output = crate::codegen::i64x1;
-}
+impl_shuffle! { [u32; 1], i64, crate::codegen::i64x1 }
 */
-impl Shuffle<[u32; 2]> for i64 {
-    type Output = crate::codegen::i64x2;
-}
-impl Shuffle<[u32; 4]> for i64 {
-    type Output = crate::codegen::i64x4;
-}
-impl Shuffle<[u32; 8]> for i64 {
-    type Output = crate::codegen::i64x8;
-}
+impl_shuffle! { [u32; 2], i64, crate::codegen::i64x2 }
+impl_shuffle! { [u32; 4], i64, crate::codegen::i64x4 }
+impl_shuffle! { [u32; 8], i64, crate::codegen::i64x8 }
 
 /* FIXME: 64-bit single element vector
-impl Shuffle<[u32; 1]> for u64 {
-    type Output = crate::codegen::u64x1;
-}
+impl_shuffle! { [u32; 1], i64, crate::codegen::i64x1 }
 */
-impl Shuffle<[u32; 2]> for u64 {
-    type Output = crate::codegen::u64x2;
-}
-impl Shuffle<[u32; 4]> for u64 {
-    type Output = crate::codegen::u64x4;
-}
-impl Shuffle<[u32; 8]> for u64 {
-    type Output = crate::codegen::u64x8;
-}
+impl_shuffle! { [u32; 2], u64, crate::codegen::u64x2 }
+impl_shuffle! { [u32; 4], u64, crate::codegen::u64x4 }
+impl_shuffle! { [u32; 8], u64, crate::codegen::u64x8 }
 
 /* FIXME: 64-bit single element vector
-impl Shuffle<[u32; 1]> for f64 {
-    type Output = crate::codegen::f64x1;
-}
+impl_shuffle! { [u32; 1], i64, crate::codegen::i64x1 }
 */
-impl Shuffle<[u32; 2]> for f64 {
-    type Output = crate::codegen::f64x2;
-}
-impl Shuffle<[u32; 4]> for f64 {
-    type Output = crate::codegen::f64x4;
-}
-impl Shuffle<[u32; 8]> for f64 {
-    type Output = crate::codegen::f64x8;
-}
+impl_shuffle! { [u32; 2], f64, crate::codegen::f64x2 }
+impl_shuffle! { [u32; 4], f64, crate::codegen::f64x4 }
+impl_shuffle! { [u32; 8], f64, crate::codegen::f64x8 }
 
 /* FIXME: 64-bit single element vector
-impl Shuffle<[u32; 1]> for m64 {
-    type Output = crate::codegen::m64x1;
-}
+impl_shuffle! { [u32; 1], i64, crate::codegen::i64x1 }
 */
-impl Shuffle<[u32; 2]> for m64 {
-    type Output = crate::codegen::m64x2;
-}
-impl Shuffle<[u32; 4]> for m64 {
-    type Output = crate::codegen::m64x4;
-}
-impl Shuffle<[u32; 8]> for m64 {
-    type Output = crate::codegen::m64x8;
-}
+impl_shuffle! { [u32; 2], m64, crate::codegen::m64x2 }
+impl_shuffle! { [u32; 4], m64, crate::codegen::m64x4 }
+impl_shuffle! { [u32; 8], m64, crate::codegen::m64x8 }
 
-impl Shuffle<[u32; 2]> for isize {
-    type Output = crate::codegen::isizex2;
-}
-impl Shuffle<[u32; 4]> for isize {
-    type Output = crate::codegen::isizex4;
-}
-impl Shuffle<[u32; 8]> for isize {
-    type Output = crate::codegen::isizex8;
-}
+impl_shuffle! { [u32; 2], isize, crate::codegen::isizex2 }
+impl_shuffle! { [u32; 4], isize, crate::codegen::isizex4 }
+impl_shuffle! { [u32; 8], isize, crate::codegen::isizex8 }
 
-impl Shuffle<[u32; 2]> for usize {
-    type Output = crate::codegen::usizex2;
-}
-impl Shuffle<[u32; 4]> for usize {
-    type Output = crate::codegen::usizex4;
-}
-impl Shuffle<[u32; 8]> for usize {
-    type Output = crate::codegen::usizex8;
-}
+impl_shuffle! { [u32; 2], usize, crate::codegen::usizex2 }
+impl_shuffle! { [u32; 4], usize, crate::codegen::usizex4 }
+impl_shuffle! { [u32; 8], usize, crate::codegen::usizex8 }
 
+impl_shuffle! { [u32; 2], msize, crate::codegen::msizex2 }
+impl_shuffle! { [u32; 4], msize, crate::codegen::msizex4 }
+impl_shuffle! { [u32; 8], msize, crate::codegen::msizex8 }
+
+impl<T> Seal<[u32; 2]> for *const T {}
 impl<T> Shuffle<[u32; 2]> for *const T {
     type Output = crate::codegen::cptrx2<T>;
 }
+impl<T> Seal<[u32; 4]> for *const T {}
 impl<T> Shuffle<[u32; 4]> for *const T {
     type Output = crate::codegen::cptrx4<T>;
 }
+impl<T> Seal<[u32; 8]> for *const T {}
 impl<T> Shuffle<[u32; 8]> for *const T {
     type Output = crate::codegen::cptrx8<T>;
 }
 
+impl<T> Seal<[u32; 2]> for *mut T {}
 impl<T> Shuffle<[u32; 2]> for *mut T {
     type Output = crate::codegen::mptrx2<T>;
 }
+impl<T> Seal<[u32; 4]> for *mut T {}
 impl<T> Shuffle<[u32; 4]> for *mut T {
     type Output = crate::codegen::mptrx4<T>;
 }
+impl<T> Seal<[u32; 8]> for *mut T {}
 impl<T> Shuffle<[u32; 8]> for *mut T {
     type Output = crate::codegen::mptrx8<T>;
 }
 
-impl Shuffle<[u32; 2]> for msize {
-    type Output = crate::codegen::msizex2;
-}
-impl Shuffle<[u32; 4]> for msize {
-    type Output = crate::codegen::msizex4;
-}
-impl Shuffle<[u32; 8]> for msize {
-    type Output = crate::codegen::msizex8;
-}
+impl_shuffle! { [u32; 1], i128, crate::codegen::i128x1 }
+impl_shuffle! { [u32; 2], i128, crate::codegen::i128x2 }
+impl_shuffle! { [u32; 4], i128, crate::codegen::i128x4 }
 
-impl Shuffle<[u32; 1]> for i128 {
-    type Output = crate::codegen::i128x1;
-}
-impl Shuffle<[u32; 2]> for i128 {
-    type Output = crate::codegen::i128x2;
-}
-impl Shuffle<[u32; 4]> for i128 {
-    type Output = crate::codegen::i128x4;
-}
+impl_shuffle! { [u32; 1], u128, crate::codegen::u128x1 }
+impl_shuffle! { [u32; 2], u128, crate::codegen::u128x2 }
+impl_shuffle! { [u32; 4], u128, crate::codegen::u128x4 }
 
-impl Shuffle<[u32; 1]> for u128 {
-    type Output = crate::codegen::u128x1;
-}
-impl Shuffle<[u32; 2]> for u128 {
-    type Output = crate::codegen::u128x2;
-}
-impl Shuffle<[u32; 4]> for u128 {
-    type Output = crate::codegen::u128x4;
-}
-
-impl Shuffle<[u32; 1]> for m128 {
-    type Output = crate::codegen::m128x1;
-}
-impl Shuffle<[u32; 2]> for m128 {
-    type Output = crate::codegen::m128x2;
-}
-impl Shuffle<[u32; 4]> for m128 {
-    type Output = crate::codegen::m128x4;
-}
+impl_shuffle! { [u32; 1], m128, crate::codegen::m128x1 }
+impl_shuffle! { [u32; 2], m128, crate::codegen::m128x2 }
+impl_shuffle! { [u32; 4], m128, crate::codegen::m128x4 }

--- a/src/codegen/vPtr.rs
+++ b/src/codegen/vPtr.rs
@@ -8,6 +8,7 @@ macro_rules! impl_simd_ptr {
         pub struct $tuple_id<$ty>($(crate $tys),*);
         //^^^^^^^ leaked through SimdArray
 
+        impl<$ty> crate::sealed::Seal for [$ptr_ty; $elem_count] {}
         impl<$ty> crate::sealed::SimdArray for [$ptr_ty; $elem_count] {
             type Tuple = $tuple_id<$ptr_ty>;
             type T = $ptr_ty;
@@ -15,6 +16,7 @@ macro_rules! impl_simd_ptr {
             type NT = [u32; $elem_count];
         }
 
+        impl<$ty> crate::sealed::Seal for $tuple_id<$ptr_ty> {}
         impl<$ty> crate::sealed::Simd for $tuple_id<$ptr_ty> {
             type Element = $ptr_ty;
             const LANES: usize = $elem_count;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,8 @@ mod api;
 mod codegen;
 mod sealed;
 
+pub use crate::sealed::{Simd as SimdVector, Shuffle, SimdArray, Mask};
+
 /// Packed SIMD vector type.
 ///
 /// # Examples
@@ -274,6 +276,8 @@ pub struct Simd<A: sealed::SimdArray>(
     // to call the shuffle intrinsics.
     #[doc(hidden)] pub <A as sealed::SimdArray>::Tuple,
 );
+
+impl<A: sealed::SimdArray> sealed::Seal for Simd<A> {}
 
 /// Wrapper over `T` implementing a lexicoraphical order via the `PartialOrd`
 /// and/or `Ord` traits.

--- a/src/masks.rs
+++ b/src/masks.rs
@@ -6,6 +6,7 @@ macro_rules! impl_mask_ty {
         #[derive(Copy, Clone)]
         pub struct $id($elem_ty);
 
+        impl crate::sealed::Seal for $id {}
         impl crate::sealed::Mask for $id {
             fn test(&self) -> bool {
                 $id::test(self)

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,8 +1,11 @@
 //! Sealed traits
 
+/// A sealed trait, this is logically private to the crate
+/// and will prevent implementations from outside the crate
+pub trait Seal<T = ()> {}
+
 /// Trait implemented by arrays that can be SIMD types.
-#[doc(hidden)]
-pub trait SimdArray {
+pub trait SimdArray: Seal {
     /// The type of the #[repr(simd)] type.
     type Tuple: Copy + Clone;
     /// The element type of the vector.
@@ -16,7 +19,7 @@ pub trait SimdArray {
 /// This traits is used to constraint the arguments
 /// and result type of the portable shuffles.
 #[doc(hidden)]
-pub trait Shuffle<Lanes> {
+pub trait Shuffle<Lanes>: Seal<Lanes> {
     // Lanes is a `[u32; N]` where `N` is the number of vector lanes
 
     /// The result type of the shuffle.
@@ -24,8 +27,7 @@ pub trait Shuffle<Lanes> {
 }
 
 /// This trait is implemented by all SIMD vector types.
-#[doc(hidden)]
-pub trait Simd {
+pub trait Simd: Seal {
     /// Element type of the SIMD vector
     type Element;
     /// The number of elements in the SIMD vector.
@@ -35,7 +37,6 @@ pub trait Simd {
 }
 
 /// This trait is implemented by all mask types
-#[doc(hidden)]
-pub trait Mask {
+pub trait Mask: Seal {
     fn test(&self) -> bool;
 }


### PR DESCRIPTION
This implements #258 and safely exposes all the traits inside of the `sealed` module without allowing outside implementations of these traits. This allows them the be used as generic bounds.